### PR TITLE
Allow feed URL to be edited

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/option/feed/FeedOptionDrawer.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/option/feed/FeedOptionDrawer.kt
@@ -97,6 +97,9 @@ fun FeedOptionDrawer(
                     },
                     onAddNewGroup = {
                         feedOptionViewModel.dispatch(FeedOptionViewAction.ShowNewGroupDialog)
+                    },
+                    onFeedUrlClick = {
+                        feedOptionViewModel.dispatch(FeedOptionViewAction.ShowChangeUrlDialog)
                     }
                 )
             }
@@ -140,6 +143,24 @@ fun FeedOptionDrawer(
             feedOptionViewModel.dispatch(FeedOptionViewAction.Rename)
             feedOptionViewModel.dispatch(FeedOptionViewAction.Hide(scope))
             context.showToast(toastString)
+        }
+    )
+
+    TextFieldDialog(
+        visible = viewState.changeUrlDialogVisible,
+        title = stringResource(R.string.change_url),
+        icon = Icons.Outlined.Edit,
+        value = viewState.newUrl,
+        placeholder = stringResource(R.string.feed_url_placeholder),
+        onValueChange = {
+            feedOptionViewModel.dispatch(FeedOptionViewAction.InputNewUrl(it))
+        },
+        onDismissRequest = {
+            feedOptionViewModel.dispatch(FeedOptionViewAction.HideChangeUrlDialog)
+        },
+        onConfirm = {
+            feedOptionViewModel.dispatch(FeedOptionViewAction.ChangeUrl)
+            feedOptionViewModel.dispatch(FeedOptionViewAction.Hide(scope))
         }
     )
 }

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/ResultView.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/ResultView.kt
@@ -1,7 +1,5 @@
 package me.ash.reader.ui.page.home.feeds.subscribe
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -24,7 +22,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -53,6 +50,7 @@ fun ResultView(
     unsubscribeOnClick: () -> Unit = {},
     onGroupClick: (groupId: String) -> Unit = {},
     onAddNewGroup: () -> Unit = {},
+    onFeedUrlClick: () -> Unit = {}
 ) {
     LaunchedEffect(Unit) {
         if (groups.isNotEmpty() && selectedGroupId.isEmpty()) onGroupClick(groups.first().id)
@@ -61,7 +59,7 @@ fun ResultView(
     Column(
         modifier = modifier.verticalScroll(rememberScrollState())
     ) {
-        Link(text = link)
+        EditableUrl(text = link, onFeedUrlClick)
         Spacer(modifier = Modifier.height(26.dp))
 
         Preset(
@@ -86,10 +84,10 @@ fun ResultView(
 }
 
 @Composable
-private fun Link(
+private fun EditableUrl(
     text: String,
+    onClick: () -> Unit
 ) {
-    val context = LocalContext.current
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center
@@ -97,9 +95,7 @@ private fun Link(
         SelectionContainer {
             Text(
                 modifier = Modifier.roundClick {
-                    context.startActivity(
-                        Intent(Intent.ACTION_VIEW, Uri.parse(text))
-                    )
+                    onClick()
                 },
                 text = text,
                 color = MaterialTheme.colorScheme.outline.copy(alpha = 0.7f),

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -43,6 +43,7 @@
     <string name="all_move_to_group_tip">将 \"%1$s\" 分组中的所有订阅源移动至 \"%2$s\" 分组。</string>
     <string name="all_move_to_group_toast">已全部移动至 \"%1$s\" 分组</string>
     <string name="rename">重命名</string>
+    <string name="change_url">Change URL</string>
     <string name="rename_toast">已重命名为 \"%1$s\"</string>
     <string name="create_new_group">新建分组</string>
     <string name="name">名称</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="all_move_to_group_tip">Move all feeds in the \"%1$s\" group to the \"%2$s\" group.</string>
     <string name="all_move_to_group_toast">Moved all to \"%1$s\" group</string>
     <string name="rename">Rename</string>
+    <string name="change_url">Change URL</string>
+    <string name="feed_url_placeholder" translatable="false">http://example.com/feed.rss</string>
     <string name="rename_toast">Renamed to \"%1$s\"</string>
     <string name="create_new_group">Create New Group</string>
     <string name="name">Name</string>


### PR DESCRIPTION
Pops up a dialog with a text field allowing editing of the feed url

Design/implementation is the same as editing feed name- click on the feed url and a dialog is shown

Not purging articles from old URL when updating the URL btw. Can do that if desired, lmk

And missing chinese translation for "Feed URL", feel free to edit that or let me know what I should put there