### PR TITLE
fix img url for flow page

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
@@ -25,6 +25,7 @@ import me.ash.reader.ui.component.FeedIcon
 import me.ash.reader.ui.component.base.RYAsyncImage
 import me.ash.reader.ui.component.base.SIZE_1000
 import me.ash.reader.ui.theme.Shape20
+import java.net.URI
 
 @Composable
 fun ArticleItem(
@@ -136,12 +137,17 @@ fun ArticleItem(
 
             // Image
             if (articleWithFeed.article.img != null && articleListImage.value) {
+                var imgUrl: String = articleWithFeed.article.img!!
+                if (imgUrl.startsWith("/")) {
+                    val uri = URI.create(articleWithFeed.feed.url)
+                    imgUrl = "${uri.scheme}://${uri.host}$imgUrl"
+                }
                 RYAsyncImage(
                     modifier = Modifier
                         .padding(start = 10.dp)
                         .size(80.dp)
                         .clip(Shape20),
-                    data = articleWithFeed.article.img,
+                    data = imgUrl,
                     scale = Scale.FILL,
                     precision = Precision.INEXACT,
                     size = SIZE_1000,


### PR DESCRIPTION
If a image uses a relative path,then it will display incorrectly in flow page. 