### PR TITLE
Fix parsing of srcset images

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/reader/HtmlToComposable.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/reader/HtmlToComposable.kt
@@ -755,7 +755,7 @@ internal class ImageCandidates(
      * Might throw if hasImage returns false
      */
     fun getBestImageForMaxSize(maxSize: Size, pixelDensity: Float): String {
-        val setCandidate = srcSet.splitToSequence(",")
+        val setCandidate = srcSet.splitToSequence(", ")
             .map { it.trim() }
             .map { it.split(SpaceRegex).take(2).map { x -> x.trim() } }
             .fold(100f to "") { acc, candidate ->
@@ -787,10 +787,10 @@ internal class ImageCandidates(
             }
             .second
 
-        if (setCandidate.isNotBlank()) {
-            return StringUtil.resolve(baseUrl, setCandidate)
-        }
-        return StringUtil.resolve(baseUrl, absSrc)
+        return StringUtil.resolve(
+            baseUrl,
+            setCandidate.takeIf { it.isNotBlank() } ?: absSrc
+        )
     }
 }
 


### PR DESCRIPTION
The image in some feeds like Politico or Substack cannot be displayed in Feeder and Read You.

The change is the same as [this commit](https://gitlab.com/spacecowboy/Feeder/-/commit/8e662118dc5844f09ce84e805bd26915627b9d5e) in Feeder. 