### PR TITLE
Rename Feedlly to the correct name of Feedly

### DIFF
--- a/app/src/main/java/me/ash/reader/data/model/account/AccountType.kt
+++ b/app/src/main/java/me/ash/reader/data/model/account/AccountType.kt
@@ -30,7 +30,7 @@ class AccountType(val id: Int) {
             2 -> context.getString(R.string.fever)
             3 -> context.getString(R.string.google_reader)
             4 -> context.getString(R.string.fresh_rss)
-            5 -> context.getString(R.string.feedlly)
+            5 -> context.getString(R.string.feedly)
             6 -> context.getString(R.string.inoreader)
             else -> context.getString(R.string.unknown)
         }
@@ -57,7 +57,7 @@ class AccountType(val id: Int) {
         val Fever = AccountType(2)
         val GoogleReader = AccountType(3)
         val FreshRSS = AccountType(4)
-        val Feedlly = AccountType(5)
+        val Feedly = AccountType(5)
         val Inoreader = AccountType(6)
     }
 }

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AddAccountsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AddAccountsPage.kt
@@ -75,8 +75,8 @@ fun AddAccountsPage(
                     )
                     SettingItem(
                         enable = false,
-                        title = stringResource(R.string.feedlly),
-                        desc = stringResource(R.string.feedlly_desc),
+                        title = stringResource(R.string.feedly),
+                        desc = stringResource(R.string.feedly_desc),
                         iconPainter = painterResource(id = R.drawable.ic_feedly),
                         onClick = {},
                     ) {}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,11 +351,11 @@
     <string name="fever" translatable="false">Fever</string>
     <string name="google_reader" translatable="false">Google Reader</string>
     <string name="fresh_rss" translatable="false">FreshRSS</string>
-    <string name="feedlly" translatable="false">Feedlly</string>
+    <string name="feedly" translatable="false">Feedly</string>
     <string name="inoreader" translatable="false">Inoreader</string>
     <string name="local_desc">On this device</string>
     <string name="services">Services</string>
-    <string name="feedlly_desc" translatable="false">feedlly.com</string>
+    <string name="feedly_desc" translatable="false">feedll.com</string>
     <string name="inoreader_desc" translatable="false">inoreader.com</string>
     <string name="self_hosted">Self-Hosted</string>
     <string name="fresh_rss_desc" translatable="false">freshrss.org</string>


### PR DESCRIPTION
Feedly is written as Feedlly in the app. The domain in the app with the double `l` also redirects to an advertisment domain, instead of the correct https://feedly.com

This PR fixes the string values and variable names.