### PR TITLE
chore: move package from Android Manifest to build files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,6 +90,7 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    namespace 'me.ash.reader'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="me.ash.reader">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
This migration is done by the [AGP Upgrade Assistant](https://developer.android.google.cn/studio/build/agp-upgrade-assistant)