### PR TITLE
Bump Material to 1.0.1 version and fix "Always Expand" preview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,12 +15,12 @@ if (keyPropsFile.exists()) {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "me.ash.reader"
         minSdk 26
-        targetSdk 32
+        targetSdk 33
         versionCode 18
         versionName "0.9.7"
 
@@ -70,7 +70,7 @@ android {
         }
     }
     kotlinOptions {
-        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/src/main/java/me/ash/reader/ui/component/base/FeedbackIconButton.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/FeedbackIconButton.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FeedbackIconButton(
     modifier: Modifier = Modifier,

--- a/app/src/main/java/me/ash/reader/ui/component/base/RYOutlineTextField.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/RYOutlineTextField.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import kotlinx.coroutines.delay
 import me.ash.reader.R
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RYOutlineTextField(
     readOnly: Boolean = false,

--- a/app/src/main/java/me/ash/reader/ui/component/base/RYTextField.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/RYTextField.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import kotlinx.coroutines.delay
 import me.ash.reader.R
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RYTextField(
     readOnly: Boolean,

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedItem.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedItem.kt
@@ -2,6 +2,7 @@ package me.ash.reader.ui.page.home.feeds
 
 import RYExtensibleVisibility
 import android.view.HapticFeedbackConstants
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Badge
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,7 +29,7 @@ import me.ash.reader.ui.page.home.feeds.drawer.feed.FeedOptionViewModel
 import me.ash.reader.ui.theme.ShapeBottom32
 
 @OptIn(
-    androidx.compose.foundation.ExperimentalFoundationApi::class,
+    ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class,
 )
 @Composable
 fun FeedItem(

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/SearchBar.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/SearchBar.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import me.ash.reader.R
 import me.ash.reader.data.constant.ElevationTokens
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchBar(
     value: String,

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/TopBar.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/TopBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SmallTopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -27,6 +28,7 @@ import me.ash.reader.ui.ext.share
 import me.ash.reader.ui.ext.surfaceColorAtElevation
 import me.ash.reader.ui.page.common.RouteName
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopBar(
     navController: NavHostController,

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPagePreview.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPagePreview.kt
@@ -102,7 +102,7 @@ fun FeedsPagePreview(
             alpha = groupAlpha,
             indicatorAlpha = groupIndicatorAlpha,
         )
-        FeedItemSwitcher(
+        FeedItemExpandSwitcher(
             groupAlpha = groupAlpha,
             feedBadgeAlpha = feedBadgeAlpha,
             isExpanded = groupListExpand.value)
@@ -121,24 +121,24 @@ fun FeedsPagePreview(
 
 @Stable
 @Composable
-fun FeedItemSwitcher(groupAlpha: Float,feedBadgeAlpha: Float ,isExpanded: Boolean) {
-    if (isExpanded) {
-        FeedItem(
-            feed = generateFeedPreview(),
-            alpha = groupAlpha,
-            badgeAlpha = feedBadgeAlpha,
-            isEnded = { true },
-            isExpanded = { true },
-        )
-    } else {
-        FeedItem(
-            feed = generateFeedPreview(),
-            alpha = groupAlpha,
-            badgeAlpha = feedBadgeAlpha,
-            isEnded = { true },
-            isExpanded = { false },
-        )
-    }
+fun FeedItemExpandSwitcher(groupAlpha: Float,feedBadgeAlpha: Float ,isExpanded: Boolean) {
+    FeedPreview(
+        groupAlpha = groupAlpha,
+        feedBadgeAlpha = feedBadgeAlpha,
+        isExpanded = isExpanded
+    )
+}
+
+@Stable
+@Composable
+fun FeedPreview(groupAlpha: Float,feedBadgeAlpha: Float, isExpanded: Boolean) {
+    FeedItem(
+        feed = generateFeedPreview(),
+        alpha = groupAlpha,
+        badgeAlpha = feedBadgeAlpha,
+        isEnded = { true },
+        isExpanded = { isExpanded }
+    )
 }
 
 @Stable

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPagePreview.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPagePreview.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SmallTopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -34,6 +35,7 @@ import me.ash.reader.ui.page.home.feeds.GroupItem
 import me.ash.reader.ui.theme.palette.onDark
 import kotlin.math.ln
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FeedsPagePreview(
     topBarTonalElevation: FeedsTopBarTonalElevationPreference,

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPagePreview.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPagePreview.kt
@@ -102,13 +102,10 @@ fun FeedsPagePreview(
             alpha = groupAlpha,
             indicatorAlpha = groupIndicatorAlpha,
         )
-        FeedItem(
-            feed = generateFeedPreview(),
-            alpha = groupAlpha,
-            badgeAlpha = feedBadgeAlpha,
-            isEnded = { true },
-            isExpanded = { true },
-        )
+        FeedItemSwitcher(
+            groupAlpha = groupAlpha,
+            feedBadgeAlpha = feedBadgeAlpha,
+            isExpanded = groupListExpand.value)
         Spacer(modifier = Modifier.height(12.dp))
         FilterBar(
             filter = filter,
@@ -119,6 +116,28 @@ fun FeedsPagePreview(
         ) {
             filter = it
         }
+    }
+}
+
+@Stable
+@Composable
+fun FeedItemSwitcher(groupAlpha: Float,feedBadgeAlpha: Float ,isExpanded: Boolean) {
+    if (isExpanded) {
+        FeedItem(
+            feed = generateFeedPreview(),
+            alpha = groupAlpha,
+            badgeAlpha = feedBadgeAlpha,
+            isEnded = { true },
+            isExpanded = { true },
+        )
+    } else {
+        FeedItem(
+            feed = generateFeedPreview(),
+            alpha = groupAlpha,
+            badgeAlpha = feedBadgeAlpha,
+            isEnded = { true },
+            isExpanded = { false },
+        )
     }
 }
 

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/flow/FlowPagePreview.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/flow/FlowPagePreview.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.DoneAll
 import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SmallTopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -32,6 +33,7 @@ import me.ash.reader.ui.page.home.flow.ArticleItem
 import me.ash.reader.ui.theme.palette.onDark
 import java.util.*
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FlowPagePreview(
     topBarTonalElevation: FlowTopBarTonalElevationPreference,

--- a/app/src/main/java/me/ash/reader/ui/page/settings/tips/TipsAndSupportPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/tips/TipsAndSupportPage.kt
@@ -43,6 +43,7 @@ import me.ash.reader.ui.ext.*
 import me.ash.reader.ui.theme.palette.alwaysLight
 import me.ash.reader.ui.theme.palette.onLight
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TipsAndSupportPage(
     navController: NavHostController,

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         // https://github.com/google/accompanist/releases
         accompanist = '0.24.7-alpha'
         // https://developer.android.com/jetpack/androidx/releases/compose-material3
-        material3 = '1.0.0-alpha12'
+        material3 = '1.0.1'
         // https://developer.android.com/jetpack/androidx/releases/lifecycle
         lifecycle = '2.5.0-rc01'
         // https://developer.android.com/jetpack/androidx/releases/navigation


### PR DESCRIPTION
## Bump Material to 1.0.1
Upgrade Material to 1.0.1 version could make ripple effect more resonable, and brings more ui components, but it caused some components updateded, only WARN level.
## Fix "Always Expand" preview
Refer #369 
Some problems still, when you switch "Always Expand" off, preview will show background in grey color.