### PR TITLE
Implement article sync limit for Fever API

### DIFF
--- a/app/src/main/java/me/ash/reader/data/repository/FeverRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/data/repository/FeverRssRepository.kt
@@ -138,6 +138,7 @@ class FeverRssRepository @Inject constructor(
             // 3. Fetch the Fever articles (up to unlimited counts)
             var sinceId = account.lastArticleId?.dollarLast() ?: ""
             var itemsBody = feverAPI.getItemsSince(sinceId)
+            var itemsFetched = 0
             while (itemsBody.items?.isNotEmpty() == true) {
                 articleDao.insert(
                     *itemsBody.items?.map {
@@ -164,8 +165,9 @@ class FeverRssRepository @Inject constructor(
                         }
                     }?.toTypedArray() ?: emptyArray()
                 )
-                if (itemsBody.items?.size!! >= 50) {
+                if (itemsBody.items?.size!! >= 50 && itemsFetched <= 250) {
                     itemsBody = feverAPI.getItemsSince(sinceId)
+                    itemsFetched += 50
                 } else {
                     break
                 }


### PR DESCRIPTION
This is a super simple patch to cap the number of articles retrieved via the Fever API at 250. This patch may be helpful to cap sync times for large Fever repositories.

I will also disclaim that I don't think this patch should be left as-is; it would perhaps be a good idea to implement a configuration option for a custom article sync limit. I don't have the Android/Kotlin knowledge to do this off the top of my head, but perhaps others do.

Should serve as a partial implementation of #395.