### PR TITLE
Fix: "Mark as Read" buttons don't work (#398)

### DIFF
--- a/app/src/main/java/me/ash/reader/data/model/general/MarkAsReadConditions.kt
+++ b/app/src/main/java/me/ash/reader/data/model/general/MarkAsReadConditions.kt
@@ -19,7 +19,7 @@ enum class MarkAsReadConditions {
     ;
 
     fun toDate(): Date? = when (this) {
-        All -> null
+        All -> Date()
         else -> Calendar.getInstance().apply {
             time = Date()
             add(Calendar.DAY_OF_MONTH, when (this@MarkAsReadConditions) {

--- a/app/src/main/java/me/ash/reader/data/repository/FeverRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/data/repository/FeverRssRepository.kt
@@ -199,12 +199,13 @@ class FeverRssRepository @Inject constructor(
     ) {
         super.markAsRead(groupId, feedId, articleId, before, isUnread)
         val feverAPI = getFeverAPI()
+        var beforeUnixTimestamp = (before?.time ?: Date(Long.MAX_VALUE).time) / 1000
         when {
             groupId != null -> {
                 feverAPI.markGroup(
                     status = if (isUnread) FeverDTO.StatusEnum.Unread else FeverDTO.StatusEnum.Read,
                     id = groupId.dollarLast().toLong(),
-                    before = before?.time ?: Date(Long.MAX_VALUE).time
+                    before = beforeUnixTimestamp
                 )
             }
 
@@ -212,7 +213,7 @@ class FeverRssRepository @Inject constructor(
                 feverAPI.markFeed(
                     status = if (isUnread) FeverDTO.StatusEnum.Unread else FeverDTO.StatusEnum.Read,
                     id = feedId.dollarLast().toLong(),
-                    before = before?.time ?: Date(Long.MAX_VALUE).time
+                    before = beforeUnixTimestamp
                 )
             }
 
@@ -228,7 +229,7 @@ class FeverRssRepository @Inject constructor(
                     feverAPI.markFeed(
                         status = if (isUnread) FeverDTO.StatusEnum.Unread else FeverDTO.StatusEnum.Read,
                         id = it.id.dollarLast().toLong(),
-                        before = before?.time ?: Date(Long.MAX_VALUE).time
+                        before = beforeUnixTimestamp
                     )
                 }
             }


### PR DESCRIPTION
This PR implements two separate fixes for the issues outlined in #398. Building Read You with these changes fixes the "Mark as Read" buttons on my environment.

Here are the details:

### Part 1: Send the `before` parameter correctly

As detailed in the [original docs](https://feedafever.com/api), the Fever API requires a `before` parameter (formatted as a Unix timestamp) in requests to update a feed or category as read (`before` a certain time). My prior understanding was that this is meant to be represented in seconds; the [Wikipedia entry](https://en.wikipedia.org/wiki/Unix_time) for Unix time and some of my own investigations [1][2][3] support this. Most applications (including popular Fever endpoints) seem to expect seconds.

Read You, however, appears to send the Fever `before` parameter as _milliseconds_ instead of seconds. This causes the Fever endpoints to think that the request is to mark all stories _before some time in the extremely distant future_ as read. This is obviously not what the user wants.

Unfortunately, the original Fever API docs don't explicitly state whether that timestamp is supposed to be in seconds or milliseconds, but given all the context clues, I think it makes most sense to send the `before` parameter as seconds. Therefore, this PR simply converts milliseconds to seconds before performing the POST request against the Fever API.

### Part 2: Send the `before` parameter correctly (...again)

When clicking the `Mark All as Read` button, Read You defaults the Fever `before` parameter to a value of `Date(Long.MAX_VALUE).time`. While this makes some sense, it appears to break at least some RSS readers, who just drop the request and don't mark anything as read. Converting this time to seconds doesn't help. Instead, this PR sets that value to the current time, which makes more logical sense and - crucially - appears to actually work.

Tagging @Ashinch for review. Resolves #398 and resolves #383 (please confirm if you're able @scottbetza)

Love the app, and can't wait to see where it goes next! :smile:

References

[1]: Read You's [own Fever documentation](https://github.com/Ashinch/ReadYou/blob/main/app/src/main/java/me/ash/reader/data/provider/fever/FeverDTO.kt#L26) contains Unix timestamp values that make most sense as seconds, rather than milliseconds.
[2]: Miniflux's [Fever handler](https://github.com/miniflux/v2/blob/main/fever/handler.go#L460) expects time in seconds.
[3]: FreshRSS' [Fever API documentation](https://freshrss.github.io/FreshRSS/en/developers/06_Fever_API.html) contains example timestamps that also make the most sense in seconds rather than milliseconds.