### PR TITLE
Add notification permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".RYApp"


### PR DESCRIPTION
Hey thanks for the great app!

Small thing - apps targeting API 33 must add declare the notification permission, otherwise they will not be able to post notifications, see the documentation here https://developer.android.com/develop/ui/views/notifications/notification-permission

This PR just adds the permission so users can manually allow the permission, but the app should also request this permission at run-time so the user can accept it too. If you give me a heads up on how you want to do it I can make a PR for that too if you like. 

This should fix https://github.com/Ashinch/ReadYou/issues/407

<img src="https://github.com/Ashinch/ReadYou/assets/16906440/a163cd0d-f1cc-4d6a-9ab4-2b1306b3caac"  width="400" >