### PR TITLE
Fix ReadingPage recompose after returning from other page.(#346)

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsViewModel.kt
@@ -1,6 +1,8 @@
 package me.ash.reader.ui.page.home.feeds
 
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -102,7 +104,7 @@ data class FeedsUiState(
     val importantSum: Flow<String> = emptyFlow(),
     val groupWithFeedList: Flow<List<GroupFeedsView>> = emptyFlow(),
     val listState: LazyListState = LazyListState(),
-    val groupsVisible: Boolean = true,
+    val groupsVisible: SnapshotStateMap<String, Boolean> = mutableStateMapOf(),
 )
 
 sealed class GroupFeedsView {

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -42,8 +41,10 @@ fun ReadingPage(
 
     LaunchedEffect(Unit) {
         navController.currentBackStackEntryFlow.collect {
-            it.arguments?.getString("articleId")?.let {
-                readingViewModel.initData(it)
+            it.arguments?.getString("articleId")?.let { articleId ->
+                if (readingUiState.articleWithFeed?.article?.id != articleId) {
+                    readingViewModel.initData(articleId)
+                }
             }
         }
     }


### PR DESCRIPTION
#346
第一个问题表现在于ReadingPage中的LaunchedEffect在每次compose中都会collect当前路由传参articleId，会导致一次页面的重新加载，解决方法就是仅在articleId不同时才刷新。

第二个问题改用ViewModel以及StateFlow保存状态即可，目前只是修复了分组的展开、收起的状态保存，至于列表的滚动，改动可能不小，等我有空再改吧。