### PR TITLE
New option: Show starred as unread

### DIFF
--- a/app/src/main/java/me/ash/reader/data/model/preference/FlowArticleListStarredAlphaPreference.kt
+++ b/app/src/main/java/me/ash/reader/data/model/preference/FlowArticleListStarredAlphaPreference.kt
@@ -1,0 +1,42 @@
+package me.ash.reader.data.model.preference
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import me.ash.reader.ui.ext.DataStoreKeys
+import me.ash.reader.ui.ext.dataStore
+import me.ash.reader.ui.ext.put
+
+sealed class FlowArticleListStarredAlphaPreference(val value: Boolean) : Preference() {
+    object ON : FlowArticleListStarredAlphaPreference(true)
+    object OFF : FlowArticleListStarredAlphaPreference(false)
+
+    override fun put(context: Context, scope: CoroutineScope) {
+        scope.launch {
+            context.dataStore.put(
+                DataStoreKeys.FlowArticleListStarredAlpha,
+                value
+            )
+        }
+    }
+
+    companion object {
+
+        val default = ON
+        val values = listOf(ON, OFF)
+
+        fun fromPreferences(preferences: Preferences) =
+            when (preferences[DataStoreKeys.FlowArticleListStarredAlpha.key]) {
+                true -> ON
+                false -> OFF
+                else -> default
+            }
+    }
+}
+
+operator fun FlowArticleListStarredAlphaPreference.not(): FlowArticleListStarredAlphaPreference =
+    when (value) {
+        true -> FlowArticleListStarredAlphaPreference.OFF
+        false -> FlowArticleListStarredAlphaPreference.ON
+    }

--- a/app/src/main/java/me/ash/reader/data/model/preference/Preference.kt
+++ b/app/src/main/java/me/ash/reader/data/model/preference/Preference.kt
@@ -46,9 +46,8 @@ fun Preferences.toSettings(): Settings {
         flowArticleListImage = FlowArticleListImagePreference.fromPreferences(this),
         flowArticleListDesc = FlowArticleListDescPreference.fromPreferences(this),
         flowArticleListTime = FlowArticleListTimePreference.fromPreferences(this),
-        flowArticleListDateStickyHeader = FlowArticleListDateStickyHeaderPreference.fromPreferences(
-            this
-        ),
+        flowArticleListDateStickyHeader = FlowArticleListDateStickyHeaderPreference.fromPreferences(this),
+        flowArticleListStarredAlpha = FlowArticleListStarredAlphaPreference.fromPreferences(this),
         flowArticleListTonalElevation = FlowArticleListTonalElevationPreference.fromPreferences(this),
 
         // Reading page

--- a/app/src/main/java/me/ash/reader/data/model/preference/Settings.kt
+++ b/app/src/main/java/me/ash/reader/data/model/preference/Settings.kt
@@ -48,6 +48,7 @@ data class Settings(
     val flowArticleListDesc: FlowArticleListDescPreference = FlowArticleListDescPreference.default,
     val flowArticleListTime: FlowArticleListTimePreference = FlowArticleListTimePreference.default,
     val flowArticleListDateStickyHeader: FlowArticleListDateStickyHeaderPreference = FlowArticleListDateStickyHeaderPreference.default,
+    val flowArticleListStarredAlpha: FlowArticleListStarredAlphaPreference = FlowArticleListStarredAlphaPreference.default,
     val flowArticleListTonalElevation: FlowArticleListTonalElevationPreference = FlowArticleListTonalElevationPreference.default,
 
     // Reading page
@@ -137,6 +138,8 @@ val LocalFlowArticleListTime =
     compositionLocalOf<FlowArticleListTimePreference> { FlowArticleListTimePreference.default }
 val LocalFlowArticleListDateStickyHeader =
     compositionLocalOf<FlowArticleListDateStickyHeaderPreference> { FlowArticleListDateStickyHeaderPreference.default }
+val LocalFlowArticleListStarredAlpha =
+    compositionLocalOf<FlowArticleListStarredAlphaPreference> { FlowArticleListStarredAlphaPreference.default }
 val LocalFlowArticleListTonalElevation =
     compositionLocalOf<FlowArticleListTonalElevationPreference> { FlowArticleListTonalElevationPreference.default }
 
@@ -223,6 +226,7 @@ fun SettingsProvider(
         LocalFlowArticleListDesc provides settings.flowArticleListDesc,
         LocalFlowArticleListTime provides settings.flowArticleListTime,
         LocalFlowArticleListDateStickyHeader provides settings.flowArticleListDateStickyHeader,
+        LocalFlowArticleListStarredAlpha provides settings.flowArticleListStarredAlpha,
         LocalFlowArticleListTonalElevation provides settings.flowArticleListTonalElevation,
         LocalFlowFilterBarStyle provides settings.flowFilterBarStyle,
         LocalFlowFilterBarFilled provides settings.flowFilterBarFilled,

--- a/app/src/main/java/me/ash/reader/data/repository/FeverRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/data/repository/FeverRssRepository.kt
@@ -143,16 +143,19 @@ class FeverRssRepository @Inject constructor(
             while (itemsBody.items?.isNotEmpty() == true) {
                 articleDao.insert(
                     *itemsBody.items?.map {
+                        val readability4JShortDescription = try {
+                            Readability4JExtended("", it.html ?: "").parse().textContent ?: ""
+                        } catch (e: java.lang.IllegalStateException) {
+                            ""
+                        }
+
                         Article(
                             id = accountId.spacerDollar(it.id!!),
                             date = it.created_on_time?.run { Date(this * 1000) } ?: Date(),
                             title = Html.fromHtml(it.title ?: context.getString(R.string.empty)).toString(),
                             author = it.author,
                             rawDescription = it.html ?: "",
-                            shortDescription = (Readability4JExtended("", it.html ?: "")
-                                .parse().textContent ?: "")
-                                .take(110)
-                                .trim(),
+                            shortDescription = readability4JShortDescription.take(110).trim(),
                             fullContent = it.html,
                             img = rssHelper.findImg(it.html ?: ""),
                             link = it.url ?: "",

--- a/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
@@ -264,6 +264,12 @@ sealed class DataStoreKeys<T> {
             get() = booleanPreferencesKey("flowArticleListDateStickyHeader")
     }
 
+    object FlowArticleListStarredAlpha : DataStoreKeys<Boolean>() {
+
+        override val key: Preferences.Key<Boolean>
+            get() = booleanPreferencesKey("flowArticleListStarredAlpha")
+    }
+
     object FlowArticleListTonalElevation : DataStoreKeys<Int>() {
 
         override val key: Preferences.Key<Int>

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
@@ -36,6 +36,7 @@ fun ArticleItem(
     val articleListImage = LocalFlowArticleListImage.current
     val articleListDesc = LocalFlowArticleListDesc.current
     val articleListDate = LocalFlowArticleListTime.current
+    val articleListStarredAlpha = LocalFlowArticleListStarredAlpha.current
 
     Column(
         modifier = Modifier
@@ -43,7 +44,8 @@ fun ArticleItem(
             .clip(Shape20)
             .clickable { onClick(articleWithFeed) }
             .padding(horizontal = 12.dp, vertical = 12.dp)
-            .alpha(if (articleWithFeed.article.isStarred || articleWithFeed.article.isUnread) 1f else 0.5f),
+            .alpha(if (articleWithFeed.article.isUnread ||
+                (articleWithFeed.article.isStarred && articleListStarredAlpha.value)) 1f else 0.5f),
     ) {
         // Top
         Row(

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/flow/FlowPageStylePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/flow/FlowPageStylePage.kt
@@ -38,6 +38,7 @@ fun FlowPageStylePage(
     val articleListDesc = LocalFlowArticleListDesc.current
     val articleListTime = LocalFlowArticleListTime.current
     val articleListStickyDate = LocalFlowArticleListDateStickyHeader.current
+    val articleListStarredAlpha = LocalFlowArticleListStarredAlpha.current
     val articleListTonalElevation = LocalFlowArticleListTonalElevation.current
 
     val scope = rememberCoroutineScope()
@@ -181,6 +182,16 @@ fun FlowPageStylePage(
                     ) {
                         RYSwitch(activated = articleListStickyDate.value) {
                             (!articleListStickyDate).put(context, scope)
+                        }
+                    }
+                    SettingItem(
+                        title = stringResource(R.string.article_list_starred_alpha),
+                        onClick = {
+                            (!articleListStarredAlpha).put(context, scope)
+                        },
+                    ) {
+                        RYSwitch(activated = articleListStarredAlpha.value) {
+                            (!articleListStarredAlpha).put(context, scope)
                         }
                     }
                     SettingItem(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,6 +287,7 @@
     <string name="feed_names">Feed names</string>
     <string name="feed_favicons">Feed favicons</string>
     <string name="article_date_sticky_header">Sticky publication date header (experimental)</string>
+    <string name="article_list_starred_alpha">Show starred as unread</string>
     <string name="article_list">Article List</string>
     <string name="group_list">Group List</string>
     <string name="always_expand">Always expand</string>


### PR DESCRIPTION
Hi, in this pull request I have added a new Flow Option. When the `Show starred as unread` option is **unchecked** all unread articles will be displayed with `1f` alpha and all read articles will be displayed with `0.5f` alpha.

**This option does not affect what is displayed in any category, this option only affects alpha blending of read articles.**

The default behavior is not changed, this new option is enabled by default, so everything behaves as usual until the `Show starred as unread` option is manually unchecked.

**_Is this useful?_**
I have many feeds on my FreshRSS server and I often put a star on some of them so I can read them later, without this option I have to remember what I have already read and what I have to read in the starred section.

The default behavior is fine for most of us, but I think that this new option just adds more customization for the end user without interfering with app development and maintenance. 