### PR TITLE
Make navigation bar transparent in more devices.

### DIFF
--- a/app/src/main/java/me/ash/reader/MainActivity.kt
+++ b/app/src/main/java/me/ash/reader/MainActivity.kt
@@ -1,7 +1,10 @@
 package me.ash.reader
 
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN
+import android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.CompositionLocalProvider
@@ -33,6 +36,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.addFlags(FLAG_LAYOUT_IN_SCREEN or FLAG_LAYOUT_NO_LIMITS)
+        }
         Log.i("RLog", "onCreate: ${ProfileInstallerInitializer().create(this)}")
 
         // Set the language


### PR DESCRIPTION
On some devices, the navigation bar still displays a not transparent overlay cover after using `WindowCompat.setDecorFitsSystemWindows(window, false)`. This pull request make navigation bar fully transparent.

在一些系统中，像OneUI、MIUI之类的，即使使用了`WindowCompat.setDecorFitsSystemWindows(window, false)`，导航栏仍然会显示一层不完全透明的遮罩。这个pull request可以使导航栏在这些系统中完全透明。