### PR TITLE
[WIP] Partial fix for "keep archived articles"

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/repository/ArticleDao.kt
+++ b/app/src/main/java/me/ash/reader/domain/repository/ArticleDao.kt
@@ -208,7 +208,7 @@ interface ArticleDao {
         """
         DELETE FROM article
         WHERE accountId = :accountId
-        AND updateAt < :before
+        AND date < :before
         AND isUnread = 0
         AND isStarred = 0
         """


### PR DESCRIPTION
This is a very simple, partial fix for #475.

The SQL query to delete read articles was using the wrong timestamp - `updateAt` instead of `date`. `updateAt` is updated every time the client refreshes, and is relatively useless when implementing this feature. Meanwhile, `date` is the proper parameter. This patch fixes that. I've verified the patch works on both local and Fever accounts.

It's not a full fix at the moment - there are some edge cases (see comment) where unexpected behavior can still come up. But the "keep archived articles" setting should now work _most_ of the time, instead of _none_ of the time :smile: