### PR TITLE
build(deps): bump up dependencies, compile sdk, and gradle version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,7 +86,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.7'
+        kotlinCompilerExtensionVersion '1.5.8'
     }
     packagingOptions {
         resources {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
     id "androidx.navigation.safeargs.kotlin"
+    id "com.google.dagger.hilt.android"
 }
 
 def gitCommitHash = "git rev-parse --verify --short HEAD".execute().text.trim()
@@ -15,7 +16,7 @@ if (keyPropsFile.exists()) {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "me.ash.reader"
@@ -56,6 +57,9 @@ android {
             storePassword keyProps["storePassword"]
         }
     }
+    lint {
+        disable += "MissingTranslation"
+    }
     buildTypes {
         release {
             minifyEnabled true
@@ -83,7 +87,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose
+        kotlinCompilerExtensionVersion '1.5.7'
     }
     packagingOptions {
         resources {
@@ -157,36 +161,39 @@ dependencies {
     implementation "androidx.compose.material3:material3:$material3"
 
     // https://github.com/google/accompanist/releases
-    implementation "com.google.accompanist:accompanist-insets:$accompanist"
     implementation "com.google.accompanist:accompanist-systemuicontroller:$accompanist"
     implementation "com.google.accompanist:accompanist-pager:$accompanist"
     implementation "com.google.accompanist:accompanist-flowlayout:$accompanist"
     implementation "com.google.accompanist:accompanist-navigation-animation:$accompanist"
     implementation "com.google.accompanist:accompanist-swiperefresh:$accompanist"
 
+    implementation platform("androidx.compose:compose-bom:$composeBom")
+    androidTestImplementation(platform("androidx.compose:compose-bom:$composeBom"))
+
     // https://developer.android.com/jetpack/androidx/releases/compose-animation
-    implementation "androidx.compose.animation:animation-graphics:$compose"
+    implementation "androidx.compose.animation:animation-graphics"
     // https://developer.android.com/jetpack/androidx/releases/compose-ui
-    implementation "androidx.compose.ui:ui:$compose"
-    implementation "androidx.compose.ui:ui-util:$compose"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui-util"
     // https://developer.android.com/jetpack/androidx/releases/compose-material
-    implementation "androidx.compose.material:material:$compose"
-    implementation "androidx.compose.material:material-icons-extended:$compose"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose"
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.material:material-icons-extended"
+    debugImplementation "androidx.compose.ui:ui-tooling"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
 
     // hilt
-    implementation "androidx.hilt:hilt-work:1.0.0"
-    implementation "com.google.dagger:hilt-android:2.40.5"
-    kapt "com.google.dagger:hilt-android-compiler:2.40.5"
-    implementation "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
-    kapt "androidx.hilt:hilt-compiler:1.0.0"
-    implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
+    implementation "androidx.hilt:hilt-work:1.1.0"
+    implementation "com.google.dagger:hilt-android:2.50"
+    kapt "com.google.dagger:hilt-android-compiler:2.50"
+//    implementation "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
+    kapt "androidx.hilt:hilt-compiler:1.1.0"
+    implementation "androidx.hilt:hilt-navigation-compose:1.1.0"
 
     // android
-    implementation "androidx.core:core-ktx:1.7.0"
-    implementation "androidx.activity:activity-compose:1.4.0"
+    implementation "androidx.core:core-ktx:1.12.0"
+    implementation "androidx.activity:activity-compose:1.8.2"
     testImplementation "junit:junit:4.13.2"
     androidTestImplementation "androidx.test.ext:junit:1.1.3"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id "org.jetbrains.kotlin.android"
     id "kotlin-kapt"
     id "dagger.hilt.android.plugin"
-    id "androidx.navigation.safeargs.kotlin"
     id "com.google.dagger.hilt.android"
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -36,3 +36,9 @@
 
 # Provider API
 -keep class me.ash.reader.infrastructure.** { *; }
+
+# https://github.com/flutter/flutter/issues/127388
+-dontwarn org.kxml2.io.KXml**
+
+# https://youtrack.jetbrains.com/issue/KTOR-5528
+-dontwarn org.slf4j.impl.StaticLoggerBinder

--- a/app/src/main/java/me/ash/reader/infrastructure/android/NotificationHelper.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/NotificationHelper.kt
@@ -1,9 +1,12 @@
 package me.ash.reader.infrastructure.android
 
+import android.Manifest
 import android.app.*
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -69,6 +72,16 @@ class NotificationHelper @Inject constructor(
                         .setSummaryText(feedWithArticle.feed.name)
                 )
 
+            if (ActivityCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                // TODO: Consider calling
+                //    ActivityCompat#requestPermissions
+                // here to request the missing permissions, and then overriding
+                //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
+                //                                          int[] grantResults)
+                // to handle the case where the user grants the permission. See the documentation
+                // for ActivityCompat#requestPermissions for more details.
+                return
+            }
             notificationManager.notify(
                 Random().nextInt() + article.id.hashCode(),
                 builder.build().apply {

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/SearchBar.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/SearchBar.kt
@@ -62,11 +62,13 @@ fun SearchBar(
                         .height(56.dp)
                         .fillMaxWidth()
                         .focusRequester(focusRequester),
-                    colors = TextFieldDefaults.textFieldColors(
-                        textColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        containerColor = Color.Transparent,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
+                    colors = TextFieldDefaults.colors(
+                            unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
                     ),
                     value = value,
                     onValueChange = { onValueChange(it) },

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ buildscript {
 
     dependencies {
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.50'
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.6"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ buildscript {
 //         https://developer.android.com/jetpack/androidx/releases/compose-ui
 //        compose = '1.2.0-beta02'
         // https://developer.android.com/jetpack/compose/bom
-        composeBom = '2023.10.01'
+        composeBom = '2024.01.00'
         // https://github.com/google/accompanist/releases
-        accompanist = '0.32.0'
+        accompanist = '0.34.0'
         // https://developer.android.com/jetpack/androidx/releases/compose-material3
         material3 = '1.1.2'
         // https://developer.android.com/jetpack/androidx/releases/lifecycle
@@ -45,7 +45,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.2.1' apply false
     id 'com.android.library' version '8.2.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,21 @@
 buildscript {
     ext {
-        // https://developer.android.com/jetpack/androidx/releases/compose-ui
-        compose = '1.2.0-beta02'
+//         https://developer.android.com/jetpack/androidx/releases/compose-ui
+//        compose = '1.2.0-beta02'
+        // https://developer.android.com/jetpack/compose/bom
+        composeBom = '2023.10.01'
         // https://github.com/google/accompanist/releases
-        accompanist = '0.24.7-alpha'
+        accompanist = '0.32.0'
         // https://developer.android.com/jetpack/androidx/releases/compose-material3
-        material3 = '1.0.1'
+        material3 = '1.1.2'
         // https://developer.android.com/jetpack/androidx/releases/lifecycle
-        lifecycle = '2.5.0-rc01'
+        lifecycle = '2.6.2'
         // https://developer.android.com/jetpack/androidx/releases/navigation
         navigation = '2.5.0-rc01'
         // https://developer.android.com/jetpack/androidx/releases/paging
         paging = '3.1.1'
         // https://developer.android.com/jetpack/androidx/releases/room
-        room = '2.5.0-alpha01'
+        room = '2.6.1'
         // https://developer.android.com/jetpack/androidx/releases/datastore
         datastore = '1.0.0'
         // https://developer.android.com/jetpack/androidx/releases/work
@@ -21,10 +23,10 @@ buildscript {
         // https://developer.android.com/jetpack/androidx/releases/profileinstaller
         profileinstaller = '1.2.0-beta02'
         // https://square.github.io/okhttp/changelogs/changelog/
-        okhttp = '5.0.0-alpha.7'
+        okhttp = '5.0.0-alpha.12'
         retrofit2 = '2.9.0'
         // https://coil-kt.github.io/coil/changelog/
-        coil = '2.1.0'
+        coil = '2.5.0'
         // https://mvnrepository.com/artifact/com.rometools/rome
         rome = '1.18.0'
         // https://github.com/dankito/Readability4J
@@ -36,15 +38,15 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40.1'
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.5.0-alpha01"
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.50'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.6"
     }
 }
 
 plugins {
-    id 'com.android.application' version '7.4.1' apply false
-    id 'com.android.library' version '7.4.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'com.android.application' version '8.2.1' apply false
+    id 'com.android.library' version '8.2.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.21' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.parallel=true
 android.useAndroidX=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false
+android.enableR8.fullMode=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Apr 20 21:38:37 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## What did this pull request do?
- Migrate to [Compose BOM](https://developer.android.com/jetpack/compose/bom), and update Compose dependencies to Compose BOM 2023.10.01
- Update Compose compiler to 1.5.7 (requires Kotlin 1.9.21)
- Update Kotlin to 1.9.21
- Update a bunch of dependencies (hilt, coil, okhttp, room, accompanist, lifecycle)
- Update Android Gradle Plugin to 8.2.1, and Gradle to 8.0
- Update `compileSdk` to 34 (not `tragetSdk`)
- Changes are made to source to pass the lint check

> [!Note]
Potential breaking changes and bugs may probably occur during usage. Please test these changes carefully before merging this PR, or consider publishing an alpha release.
