### PR TITLE
fix(fever): authentication failure

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -35,4 +35,4 @@
 -keep class com.rometools.** { *; }
 
 # Provider API
--keep class me.ash.reader.data.provider.** { *; }
+-keep class me.ash.reader.infrastructure.rss.provider.** { *; }


### PR DESCRIPTION
#507

When refactoring the code, I overlooked modifying the `proguard-rules.pro` file, resulting in the obfuscation of the Fever API-related code. This eventually manifested as normal operation in Debug mode but triggered authentication errors in Release mode.