### PR TITLE
Fix swipe gesture attempting to mark feeds and groups as read

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -243,8 +243,8 @@ fun FlowPage(
                         }
                     ) {
                         flowViewModel.markAsRead(
-                            groupId = filterUiState.group?.id,
-                            feedId = filterUiState.feed?.id,
+                            groupId = null,
+                            feedId = null,
                             articleId = it.article.id,
                             MarkAsReadConditions.All
                             )


### PR DESCRIPTION
After some digging into #515, I think I've figured out the root cause of the various issues with "swipe to mark as read" marking unrelated items as read.

Internally, Read You has a `markAsRead` function that is called when a part of the app wants to mark an article as read. It takes a few parameters: either a group ID, feed ID, or article ID. It would take appropriate action depending on which ID was provided.

Now, an unwritten assumption of this bit of code was that _only one of the IDs would be supplied to `markAsRead` at once_. This assumption was violated by the swipe to dismiss code, which provided _all three_. This manifested as various inconsistent behavior throughout the app, especially on the Fever API - which has additional mark as read code.

The fix is simple: make sure the swipe to mark as read code only provides the article ID. That's what this PR does. I've tested it on Fever, and it seems to work.

FYI, in case you're curious, @Ashinch @kid1412621 and @nvllz. Resolves #515.