### PR TITLE
Add workaround for "Row too big to fit into CursorWindow" bug

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/android/MainActivity.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/MainActivity.kt
@@ -1,5 +1,6 @@
 package me.ash.reader.infrastructure.android
 
+import android.database.CursorWindow
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -19,7 +20,9 @@ import me.ash.reader.infrastructure.preference.LanguagesPreference
 import me.ash.reader.infrastructure.preference.SettingsProvider
 import me.ash.reader.ui.ext.languages
 import me.ash.reader.ui.page.common.HomeEntry
+import java.lang.reflect.Field
 import javax.inject.Inject
+
 
 /**
  * The Single-Activity Architecture.
@@ -45,6 +48,15 @@ class MainActivity : ComponentActivity() {
         LanguagesPreference.fromValue(languages).let {
             if (it == LanguagesPreference.UseDeviceLanguages) return@let
             it.setLocale(this)
+        }
+
+        // Workaround for https://github.com/Ashinch/ReadYou/issues/312: increase cursor window size
+        try {
+            val field: Field = CursorWindow::class.java.getDeclaredField("sCursorWindowSize")
+            field.isAccessible = true
+            field.set(null, 100 * 1024 * 1024) // 100MB is the new cursor window size
+        } catch (e: Exception) {
+            Log.e("RLog", "Unable to increase cursor window size: ${e.printStackTrace()}")
         }
 
         setContent {


### PR DESCRIPTION
The bug described in #312 is longstanding, and quite annoying - the only workaround is for users to delete all articles in the affected source and move on, but that's not ideal (articles may be missed).

From recent research into the topic, it [seems like this is a broader Android problem](https://github.com/andpor/react-native-sqlite-storage/issues/364) and not unique to Read You. Fortunately, that also means people have found fixes!

With the help of @kermes in the Read You issue, I was able to consistently reproduce the bug using the source `https://www.newtral.es/feed/`. After applying the fix suggested in the thread above, the bug no longer happens on that feed! :tada: 

@Ashinch said in the Read You bug thread that it may also be a paging issue, so we probably shouldn't consider this a permanent fix. But it does appear to be an effective workaround for a pretty common bug.