### PR TITLE
Add a debug build type

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,12 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.release
         }
+        debug {
+            applicationIdSuffix ".debug"
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            debuggable true
+        }
     }
     applicationVariants.all { variant ->
         variant.outputs.each { output ->


### PR DESCRIPTION
I personally test new features with a physical device and having a 'release' build only blocks me from easily debugging the app. This way I can handle two independent builds on a single device and easily compare the 'release' version with the 'debug' one