### PR TITLE
Image zooming feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -191,4 +191,6 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:1.1.3"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
 
+    // https://github.com/usuiat/Zoomable
+    implementation "net.engawapg.lib:zoomable:1.5.3"
 }

--- a/app/src/main/java/me/ash/reader/ui/component/reader/HtmlToComposable.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/reader/HtmlToComposable.kt
@@ -62,6 +62,9 @@ import org.jsoup.nodes.TextNode
 import java.io.InputStream
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.toggleScale
+import net.engawapg.lib.zoomable.zoomable
 
 fun LazyListScope.htmlFormattedText(
     inputStream: InputStream,
@@ -497,13 +500,21 @@ private fun TextComposer.appendTextChildren(
 //                                            }
                                             ) {
                                                 val imageSize = maxImageSize()
+                                                val zoomState = rememberZoomState()
+                                                val targetScale = 1.75f
                                                 RYAsyncImage(
                                                     modifier = Modifier
                                                         .align(Alignment.Center)
                                                         .fillMaxWidth()
                                                         .padding(horizontal = imageHorizontalPadding().dp)
                                                         .clip(imageShape())
-                                                        .clickable { },
+                                                        .clickable { }
+                                                        .zoomable(
+                                                            zoomState = zoomState,
+                                                            onDoubleTap = {
+                                                                    position -> zoomState.toggleScale(targetScale, position)
+                                                            }
+                                                        ),
                                                     data = imageCandidates.getBestImageForMaxSize(
                                                         pixelDensity = pixelDensity(),
                                                         maxSize = imageSize,


### PR DESCRIPTION
As simple as the title.

https://github.com/Ashinch/ReadYou/assets/110673332/1d45cd3c-8ede-4d21-ba31-8dd5b7eddedd

Does not affect scrolling, can be used with multiple gestures. Idk how to make it pan over the image maxSize border, but this way it still seems to be useful in most cases. Based on https://github.com/usuiat/Zoomable.

But... we can only consider this once https://github.com/Ashinch/ReadYou/pull/502 is merged, as zoomable requires more recent libraries.