### PR TITLE
refactor(greader): incrementally fetch the unread items by difference set

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/repository/ArticleDao.kt
+++ b/app/src/main/java/me/ash/reader/domain/repository/ArticleDao.kt
@@ -18,6 +18,32 @@ import java.util.Date
 @Dao
 interface ArticleDao {
 
+    @Query(
+        """
+        UPDATE article SET isStarred = :isStarred 
+        WHERE accountId = :accountId
+        AND id in (:ids)
+        """
+    )
+    fun markAsStarredByIdSet(
+        accountId: Int,
+        ids: Set<String>,
+        isStarred: Boolean,
+    ): Int
+
+    @Query(
+        """
+        UPDATE article SET isUnread = :isUnread 
+        WHERE accountId = :accountId
+        AND id in (:ids)
+        """
+    )
+    fun markAsReadByIdSet(
+        accountId: Int,
+        ids: Set<String>,
+        isUnread: Boolean,
+    ): Int
+
     @Transaction
     @RewriteQueriesToDropUnusedColumns
     @Query(

--- a/app/src/main/java/me/ash/reader/infrastructure/di/OkHttpClientModule.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/di/OkHttpClientModule.kt
@@ -122,4 +122,4 @@ object UserAgentInterceptor : Interceptor {
     }
 }
 
-const val USER_AGENT_STRING = "ReadYou / ${BuildConfig.VERSION_NAME}(${BuildConfig.VERSION_CODE})"
+const val USER_AGENT_STRING = "ReadYou/${BuildConfig.VERSION_NAME}(${BuildConfig.VERSION_CODE})"


### PR DESCRIPTION
This is a reference to Reeder's synchronization logic, which syncs well across multiple devices. The following link contains other great synchronization logic, but it was not adopted due to the solidified domain model of this application.

During the initial synchronization, it fetches all articles from the past month to provide users with a better multi-device experience. However, during subsequent synchronizations (`n`-th time), it only fetches items that have differences between the local device and the server, reducing network requests. Currently, the synchronization time is mainly blocked on replacing the database records of subscription list, which can be addressed later by revising the model. The primary method of data exchange currently relies on in-memory operations, which might not be very friendly for low-memory devices. Utilizing an database intermediate table for data exchange could resolve this issue. However, the application currently consumes excessive connection pools, resulting in a lagging experience for high-memory devices. We look forward to addressing these issues through model refactoring in future iterations.




- https://github.com/FreshRSS/FreshRSS/issues/2566#issuecomment-541317776
- https://github.com/bazqux/bazqux-api?tab=readme-ov-file
- https://github.com/theoldreader/api