### PR TITLE
fix(ui): fix alignment of search bar placeholder text

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/SearchBar.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/SearchBar.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import me.ash.reader.R
 import me.ash.reader.domain.model.constant.ElevationTokens
@@ -78,6 +79,8 @@ fun SearchBar(
                             text = placeholder,
                             style = MaterialTheme.typography.bodyLarge,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     },
                     textStyle = MaterialTheme.typography.bodyLarge,


### PR DESCRIPTION
Fix alignment of placeholder text and add an ellipsis for overflowed texts

| Before  | After |
| ------------- | ------------- |
| ![Reader-1-before](https://github.com/Ashinch/ReadYou/assets/10359255/9af175a4-e292-4258-a729-d56bc65f91ec)  | ![Reader-1-after](https://github.com/Ashinch/ReadYou/assets/10359255/8f03a2d4-ba27-4a78-9458-9f05dd2bd4f9) |
