### PR TITLE
feat(ui): format time with system locale default

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/ext/DateExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/DateExt.kt
@@ -2,13 +2,13 @@ package me.ash.reader.ui.ext
 
 import android.annotation.SuppressLint
 import android.content.Context
-import androidx.core.os.ConfigurationCompat
 import me.ash.reader.R
 import java.text.DateFormat
 import java.text.ParsePosition
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
+import java.util.Locale
 
 @SuppressLint("SimpleDateFormat")
 object DateFormat {
@@ -25,18 +25,18 @@ fun Date.formatAsString(
     onlyHourMinute: Boolean? = false,
     atHourMinute: Boolean? = false,
 ): String {
-    val locale = ConfigurationCompat.getLocales(context.resources.configuration)[0]
+    val locale = Locale.getDefault()
     val df = DateFormat.getDateInstance(DateFormat.FULL, locale)
     return when {
         onlyHourMinute == true -> {
-            SimpleDateFormat("HH:mm", locale).format(this)
+            this.toTimeString(context = context)
         }
 
         atHourMinute == true -> {
             context.getString(
                 R.string.date_at_time,
                 df.format(this),
-                SimpleDateFormat("HH:mm", locale).format(this),
+                this.toTimeString(context = context),
             )
         }
 
@@ -58,6 +58,10 @@ fun Date.formatAsString(
         }
     }
 }
+
+private fun Date.toTimeString(context: Context): String =
+    android.text.format.DateFormat.getTimeFormat(context).format(this)
+
 
 private fun String.parseToDate(
     patterns: Array<String> = arrayOf(


### PR DESCRIPTION
Instead of adding an option to configure the time format, this PR make the time to be formatted according to the app's locale and the system's 12-/24-hour clock preference.

Examples:
- 24-hour format for Japan/US: `13:00`
- 12-hour format for Japan: `午後1:30` (instead of `1:30 午後` when using `hh:mm a` for formatting)
- 12-hour format for US: `1:30 PM`
  
Close #98 