### PR TITLE
fix(ui): fetch articles only when filter changes

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -312,8 +312,9 @@ fun FlowPage(
                         flowUiState.listState.scrollToItem(0)
                     }
                 }
-                homeViewModel.changeFilter(filterUiState.copy(filter = it))
-                homeViewModel.fetchArticles()
+                if (filterUiState.filter != it) {
+                    homeViewModel.changeFilter(filterUiState.copy(filter = it))
+                }
             }
         }
     )


### PR DESCRIPTION
1. remove `fetchArticles` since `changeFilter` internally invokes that
2. call `changeFilter` only when filter changes

Before

https://github.com/Ashinch/ReadYou/assets/10359255/4ee7d27a-a871-4100-800a-3340c4796f70

After

https://github.com/Ashinch/ReadYou/assets/10359255/0822df07-d4dc-4589-8ebd-3f6f215815b5