### PR TITLE
fix(ui): fix performance & data loading issues with sticky headers disabled

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListDateStickyHeaderPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListDateStickyHeaderPreference.kt
@@ -23,7 +23,7 @@ sealed class FlowArticleListDateStickyHeaderPreference(val value: Boolean) : Pre
 
     companion object {
 
-        val default = OFF
+        val default = ON
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListDateStickyHeaderPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListDateStickyHeaderPreference.kt
@@ -23,7 +23,7 @@ sealed class FlowArticleListDateStickyHeaderPreference(val value: Boolean) : Pre
 
     companion object {
 
-        val default = ON
+        val default = OFF
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleList.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleList.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemContentType
+import androidx.paging.compose.itemKey
 import me.ash.reader.domain.model.article.ArticleFlowItem
 import me.ash.reader.domain.model.article.ArticleWithFeed
 
@@ -27,10 +29,17 @@ fun LazyListScope.ArticleList(
     onMarkBelowAsRead: ((ArticleWithFeed) -> Unit)? = null,
     onShare: ((ArticleWithFeed) -> Unit)? = null,
 ) {
-    for (index in 0 until pagingItems.itemCount) {
-        when (val item = pagingItems.peek(index)) {
-            is ArticleFlowItem.Article -> {
-                item(key = item.articleWithFeed.article.id) {
+    // https://issuetracker.google.com/issues/193785330
+    // FIXME: Using sticky header with paging-compose need to iterate through the entire list
+    //  to figure out where to add sticky headers, which significantly impacts the performance
+    if (!isShowStickyHeader) {
+        items(
+            count = pagingItems.itemCount,
+            key = pagingItems.itemKey(::key),
+            contentType = pagingItems.itemContentType(::contentType)
+        ) { index ->
+            when (val item = pagingItems[index]) {
+                is ArticleFlowItem.Article -> {
                     SwipeableArticleItem(
                         articleWithFeed = item.articleWithFeed,
                         isFilterUnread = isFilterUnread,
@@ -45,22 +54,66 @@ fun LazyListScope.ArticleList(
                         onShare = onShare
                     )
                 }
-            }
 
-            is ArticleFlowItem.Date -> {
-                if (item.showSpacer) item { Spacer(modifier = Modifier.height(40.dp)) }
-                if (isShowStickyHeader) {
-                    stickyHeader(key = item.date) {
-                        StickyHeader(item.date, isShowFeedIcon, articleListTonalElevation)
+                is ArticleFlowItem.Date -> {
+                    if (item.showSpacer) {
+                        Spacer(modifier = Modifier.height(40.dp))
                     }
-                } else {
-                    item(key = item.date) {
+                    StickyHeader(item.date, isShowFeedIcon, articleListTonalElevation)
+                }
+
+                else -> {}
+            }
+        }
+    } else {
+        for (index in 0 until pagingItems.itemCount) {
+            when (val item = pagingItems.peek(index)) {
+                is ArticleFlowItem.Article -> {
+                    item(key = key(item), contentType = contentType(item)) {
+                        SwipeableArticleItem(
+                            articleWithFeed = item.articleWithFeed,
+                            isFilterUnread = isFilterUnread,
+                            articleListTonalElevation = articleListTonalElevation,
+                            onClick = onClick,
+                            isSwipeEnabled = isSwipeEnabled,
+                            isMenuEnabled = isMenuEnabled,
+                            onToggleStarred = onToggleStarred,
+                            onToggleRead = onToggleRead,
+                            onMarkAboveAsRead = if (index == 1) null else onMarkAboveAsRead, // index == 0 -> ArticleFlowItem.Date
+                            onMarkBelowAsRead = if (index == pagingItems.itemCount - 1) null else onMarkBelowAsRead,
+                            onShare = onShare
+                        )
+                    }
+                }
+
+                is ArticleFlowItem.Date -> {
+                    if (item.showSpacer) {
+                        item { Spacer(modifier = Modifier.height(40.dp)) }
+                    }
+                    stickyHeader(key = key(item), contentType = contentType(item)) {
                         StickyHeader(item.date, isShowFeedIcon, articleListTonalElevation)
                     }
                 }
-            }
 
-            else -> {}
+                else -> {}
+            }
         }
     }
 }
+
+private fun key(item: ArticleFlowItem): String {
+    return when (item) {
+        is ArticleFlowItem.Article -> item.articleWithFeed.article.id
+        is ArticleFlowItem.Date -> item.date
+    }
+}
+
+private fun contentType(item: ArticleFlowItem): Int {
+    return when (item) {
+        is ArticleFlowItem.Article -> ARTICLE
+        is ArticleFlowItem.Date -> DATE
+    }
+}
+
+private const val ARTICLE = 1
+private const val DATE = 2


### PR DESCRIPTION
About this PR:
- Fix performance & data loading issues with sticky headers disabled
- Disable sticky headers by default

Related issues:
https://issuetracker.google.com/u/1/issues/193785330 
https://stackoverflow.com/questions/67649953/sticky-headers-with-paging-library-in-jetpack-compose