### PR TITLE
Fix mark all as read on Fever API via Miniflux

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -287,7 +287,7 @@ class FeverRssService @Inject constructor(
     ) {
         super.markAsRead(groupId, feedId, articleId, before, isUnread)
         val feverAPI = getFeverAPI()
-        val beforeUnixTimestamp = (before?.time ?: Date(Long.MAX_VALUE).time) / 1000
+        val beforeUnixTimestamp = (before?.time ?: Date().time) / 1000
         when {
             groupId != null -> {
                 feverAPI.markGroup(


### PR DESCRIPTION
As detailed in #599, Read You's "Mark All As Read" button doesn't work when connected to Miniflux via the Fever API.

It turns out the fix is pretty simple: before, Read You was sending a `before:` timestamp of `Long.MAX_VALUE`. This produced a truly enormous epoch value, and it's possible Miniflux was just not interpreting it properly.

Changing the value to the current Unix time fixes the issue on Miniflux, and should remain functional for all other backends too. (It also just makes more logical sense.)

Tagging @Ashinch @JunkFood02 for review.