### PR TITLE
feat(greader): sort categories alphabetically during sync

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -229,6 +229,7 @@ class GoogleReaderRssService @Inject constructor(
                 // 2. Fetch folder and subscription list
                 googleReaderAPI.getSubscriptionList()
                     .subscriptions.groupBy { it.categories?.first() }
+                    .toSortedMap { c1, c2 -> c1?.label.toString().compareTo(c2?.label.toString()) }
                     .forEach { (category, feeds) ->
                         val groupId =
                             accountId.spacerDollar(category?.id?.ofCategoryStreamIdToId()!!)


### PR DESCRIPTION
This has been a pet peeve of mine when using the Greader API: categories/folders aren't sorted alphabetically when in the Feeds view. The way the app works today, categories are arranged by whichever category has the _feed_ with the lowest lexicographical order, which is very unintuitive.

As an example, let's say I have the following categories and feeds:

```json
"Apples": {
    "feeds": ["Fruits of the Day"]
},
"Bananas": {
    "feeds": ["A banana a day keeps the doctor away"]
},
```

Under the current code, these categories get ordered as:

```
Bananas
Apples
```

because `A banana a day keeps the doctor away` is lexicographically before `Fruits of the Day`.

While it's true that we should probably implement some way to allow the user to manually reorder feeds, this is a quick fix that requires little effort. Plus, even if we did have manual category sorting, it's still nice to present a sensible lexicographic default.

Tagging @Ashinch and @JunkFood02 for review.