### PR TITLE
fix(preferences): revert `newVersionSize` to `newVersionSizeString`

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionSizePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionSizePreference.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.newVersionSize
+import me.ash.reader.ui.ext.DataStoreKey.Companion.newVersionSizeString
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -24,10 +24,10 @@ object NewVersionSizePreference {
 
     fun put(context: Context, scope: CoroutineScope, value: String) {
         scope.launch(Dispatchers.IO) {
-            context.dataStore.put(newVersionSize, value)
+            context.dataStore.put(newVersionSizeString, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[newVersionSize]?.key as Preferences.Key<String>] ?: default
+        preferences[DataStoreKey.keys[newVersionSizeString]?.key as Preferences.Key<String>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
@@ -97,7 +97,7 @@ data class DataStoreKey<T>(
         const val isFirstLaunch = "isFirstLaunch"
         const val newVersionPublishDate = "newVersionPublishDate"
         const val newVersionLog = "newVersionLog"
-        const val newVersionSize = "newVersionSize"
+        const val newVersionSizeString = "newVersionSizeString"
         const val newVersionDownloadUrl = "newVersionDownloadUrl"
         const val newVersionNumber = "newVersionNumber"
         const val skipVersionNumber = "skipVersionNumber"
@@ -173,7 +173,7 @@ data class DataStoreKey<T>(
             isFirstLaunch to DataStoreKey(booleanPreferencesKey(isFirstLaunch), Boolean::class.java),
             newVersionPublishDate to DataStoreKey(stringPreferencesKey(newVersionPublishDate), String::class.java),
             newVersionLog to DataStoreKey(stringPreferencesKey(newVersionLog), String::class.java),
-            newVersionSize to DataStoreKey(stringPreferencesKey(newVersionSize), String::class.java),
+            newVersionSizeString to DataStoreKey(stringPreferencesKey(newVersionSizeString), String::class.java),
             newVersionDownloadUrl to DataStoreKey(stringPreferencesKey(newVersionDownloadUrl), String::class.java),
             newVersionNumber to DataStoreKey(stringPreferencesKey(newVersionNumber), String::class.java),
             skipVersionNumber to DataStoreKey(stringPreferencesKey(skipVersionNumber), String::class.java),


### PR DESCRIPTION
In earlier versions, there was an `Int` type named `newVersionSize`. In version `0.10.0`, `newVersionSizeString` was renamed back to `newVersionSize`, causing a conversion error for earlier users when converting from `Int` to `String` type values, leading to application crashes and startup failures.

Close #730