### PR TITLE
chore(greader): add null checks in greader service

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/ext/NumberExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/NumberExt.kt
@@ -1,6 +1,6 @@
 package me.ash.reader.ui.ext
 
-fun Int.spacerDollar(str: Any): String = "$this$$str"
+infix fun Int.spacerDollar(str: Any): String = "$this$$str"
 
 fun String.dollarLast(): String = split("$").last()
 


### PR DESCRIPTION
Replace `NullPointerException` with `IllegalArgumentException`, generating human-readable stacktraces