### PR TITLE
Remove the deprecated `languages_desc` string from ressources

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -113,7 +113,6 @@
     <string name="get_new_updates_desc">يتوفَّر الإصدار %1$s</string>
     <string name="get_new_updates">احصل على التحديثات الجديدة</string>
     <string name="color_and_style">اللون والأسلوب</string>
-    <string name="languages_desc">الإنجليزيَّة، الصينيَّة، إلخ</string>
     <string name="close">أغلق</string>
     <string name="interaction_desc">صفحة البداية، استجابة اللمس</string>
     <string name="tips_and_support">التلميحات والدعم</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -103,7 +103,6 @@
     <string name="three_days">3д</string>
     <string name="seven_days">7д</string>
     <string name="languages">Езици</string>
-    <string name="languages_desc">английски, китайски и др</string>
     <string name="tips_and_support">Съвети и поддръжка</string>
     <string name="tips_and_support_desc">Относно лицензите с отворен код</string>
     <string name="browse_tos_tips">Прегледайте <i><u>Условията за ползване и Политиката за поверителност</u></i></string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -101,7 +101,6 @@
     <string name="interaction">Interacció</string>
     <string name="interaction_desc">Pàgina d\'inici, feedback hàptic</string>
     <string name="languages">Llenguatges</string>
-    <string name="languages_desc">Anglès, xinès i altres</string>
     <string name="help_translate">Ajuda a la traducció</string>
     <string name="use_device_languages">Aplica el llenguatge del dispositiu</string>
     <string name="tips_and_support_desc">Sobre les llicències de codi obert</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -102,7 +102,6 @@
     <string name="interaction">Interakce</string>
     <string name="interaction_desc">Úvodní stránka, haptická odezva</string>
     <string name="languages">Jazyky</string>
-    <string name="languages_desc">Angličtina, Čeština, více</string>
     <string name="help_translate">Pomozte nám s překladem</string>
     <string name="use_device_languages">Použít jazyk zařízení</string>
     <string name="tips_and_support">Tipy a podpora</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -101,7 +101,6 @@
     <string name="in_coding">I kode</string>
     <string name="interaction_desc">Startside, haptisk feedback</string>
     <string name="languages">Sprog</string>
-    <string name="languages_desc">Engelsk, Kinesisk, med mere</string>
     <string name="color_and_style_desc">Tema, farvestil, skriftstørrelse</string>
     <string name="interaction">Interaktion</string>
     <string name="help_translate">Hjælp med at oversætte</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -99,7 +99,6 @@
     <string name="interaction">Interaktion</string>
     <string name="interaction_desc">Haptisches Feedback beim Start</string>
     <string name="languages">Sprachen</string>
-    <string name="languages_desc">Deutsch, Englisch, andere</string>
     <string name="help_translate">Hilf uns beim Übersetzen</string>
     <string name="use_device_languages">Gerätesprache verwenden</string>
     <string name="tips_and_support">Tipps &amp; Support</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -67,7 +67,6 @@
     <string name="color_and_style">Koloro ⳤ stilo</string>
     <string name="interaction">Interago</string>
     <string name="interaction_desc">Komenca paĝo, haptika retrosciigo</string>
-    <string name="languages_desc">Angla, Ĉina, pli</string>
     <string name="help_translate">Helpu traduki</string>
     <string name="use_device_languages">Uzi aparatlingvon</string>
     <string name="tips_and_support">Konsiloj ⳤ subteno</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -102,7 +102,6 @@
     <string name="interaction">Interacción</string>
     <string name="interaction_desc">Página inicial, respuesta táctil</string>
     <string name="languages">Idiomas</string>
-    <string name="languages_desc">Inglés, Chino, más</string>
     <string name="help_translate">Ayuda para traducir</string>
     <string name="use_device_languages">Usar idioma del dispositivo</string>
     <string name="tips_and_support">Consejos y ayuda</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -99,7 +99,6 @@
     <string name="interaction">Interakzioa</string>
     <string name="interaction_desc">Abioa, ukipen-atzeraelikadura</string>
     <string name="languages">Hizkuntzak</string>
-    <string name="languages_desc">Ingelesa, Txinera, gehiago</string>
     <string name="help_translate">Itzulpenarekin lagundu</string>
     <string name="use_device_languages">Gailuaren hizkuntza erabili</string>
     <string name="tips_and_support">Aholkuak eta babesa</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -87,7 +87,6 @@
     <string name="interaction">اثر متقابل</string>
     <string name="interaction_desc">صفحه اولیه، بازخورد لمسی</string>
     <string name="languages">زبان ها</string>
-    <string name="languages_desc">انگلیسی، چینی و غیره</string>
     <string name="help_translate">کمک در ترجمه</string>
     <string name="use_device_languages">استفاده از زبان دستگاه</string>
     <string name="tips_and_support">نکات و پشتیبانی</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -62,7 +62,6 @@
     <string name="interaction">Pag-interact</string>
     <string name="interaction_desc">Nangungunang pahina, haptic feedback</string>
     <string name="languages">Mga Wika</string>
-    <string name="languages_desc">Ingles, Chinese, marami pa</string>
     <string name="help_translate">Tumulong magsalin</string>
     <string name="use_device_languages">Gamitin ang wika ng device</string>
     <string name="tips_and_support">Mga tip at support</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -102,7 +102,6 @@
     <string name="interaction">Comportement</string>
     <string name="interaction_desc">Page de démarrage, retour haptique</string>
     <string name="languages">Langues</string>
-    <string name="languages_desc">Français, anglais et plus</string>
     <string name="help_translate">Aidez-nous à traduire</string>
     <string name="use_device_languages">Utiliser la langue système</string>
     <string name="tips_and_support">Aide et assistance</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -99,7 +99,6 @@
     <string name="interaction">प्रभाव</string>
     <string name="interaction_desc">प्रारंभिक पृष्ठ, हैप्टिक फीडबैक</string>
     <string name="languages">भाषाएं</string>
-    <string name="languages_desc">अंग्रेजी , चीनी भाषा, और भी</string>
     <string name="help_translate">अनुवाद में सहायता करें</string>
     <string name="use_device_languages">डिवाइस भाषा का उपयोग करें</string>
     <string name="tips_and_support">सुझाव और सहायता</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -144,7 +144,6 @@
     <string name="color_and_style_desc">Téma, színstílus, betűméret</string>
     <string name="interaction">Interakció</string>
     <string name="languages">Nyelvek</string>
-    <string name="languages_desc">Angol, kínai és továbbiak</string>
     <string name="help_translate">Segítsen a fordításban</string>
     <string name="use_device_languages">Eszköz nyelvének használata</string>
     <string name="tips_and_support">Tippek és támogatás</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -99,7 +99,6 @@
     <string name="interaction">Interaksi</string>
     <string name="interaction_desc">Halaman awal, getaran haptik</string>
     <string name="languages">Bahasa</string>
-    <string name="languages_desc">Inggris, Mandarin, dll</string>
     <string name="help_translate">Bantu terjemahkan</string>
     <string name="use_device_languages">Gunakan bahasa perangkat</string>
     <string name="tips_and_support">Tips dan Bantuan</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -102,7 +102,6 @@
     <string name="interaction">Interazione</string>
     <string name="interaction_desc">Pagina iniziale, feedback aptico</string>
     <string name="languages">Lingue</string>
-    <string name="languages_desc">Inglese, Cinese, altre</string>
     <string name="help_translate">Aiuta a tradurre</string>
     <string name="use_device_languages">Usa la lingua del dispositivo</string>
     <string name="tips_and_support">Note e supporto</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -38,7 +38,6 @@
     <string name="interaction">אינטראקציה</string>
     <string name="interaction_desc">עמוד ראשוני, משוב ברטט</string>
     <string name="languages">שפות</string>
-    <string name="languages_desc">אנגלית, עברית ועוד</string>
     <string name="help_translate">עזרה בתרגום</string>
     <string name="use_device_languages">להשתמש בשפת המכשיר</string>
     <string name="tips_and_support">עצות ותמיכה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -33,7 +33,6 @@
     <string name="interaction">操作</string>
     <string name="interaction_desc">起動時のページ、触覚フィードバック</string>
     <string name="languages">言語</string>
-    <string name="languages_desc">英語、中国語、その他</string>
     <string name="help_translate">翻訳を手伝う</string>
     <string name="welcome">ようこそ</string>
     <string name="terms_of_service">利用規約</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -92,7 +92,6 @@
     <string name="get_new_updates_desc">ಹೊಸ ಆವೃತ್ತಿ %1$s ಲಭ್ಯವಿದೆ</string>
     <string name="color_and_style">ಬಣ್ಣ ಮತ್ತು ಶೈಲಿ</string>
     <string name="languages">ಭಾಷೆಗಳು</string>
-    <string name="languages_desc">ಇಂಗ್ಲೀಷ್, ಚೈನೀಸ್, ಹೆಚ್ಚು</string>
     <string name="help_translate">ಅನುವಾದಿಸಲು ಸಹಾಯ ಮಾಡಿ</string>
     <string name="tips_and_support">ಸಲಹೆಗಳು ಮತ್ತು ಬೆಂಬಲ</string>
     <string name="tips_and_support_desc">ಕುರಿತು, ಮುಕ್ತ ಮೂಲ ಪರವಾನಗಿಗಳು</string>

--- a/app/src/main/res/values-lzh/strings.xml
+++ b/app/src/main/res/values-lzh/strings.xml
@@ -42,7 +42,6 @@
     <string name="preset">预置</string>
     <string name="selected">已选取</string>
     <string name="allow_notification">告知往来</string>
-    <string name="languages_desc">英语、简体中文、更多</string>
     <string name="list">罗列</string>
     <string name="more">更多</string>
     <string name="add">增添</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -15,7 +15,6 @@
     <string name="mark_as_starred">Marker som stjernemerket</string>
     <string name="accounts">Kontoer</string>
     <string name="color_and_style_desc">Drakt, fargestil, skriftstørrelse</string>
-    <string name="languages_desc">Engelsk, kinesisk, med mer</string>
     <string name="terms_of_service">Tjenestevilkår</string>
     <string name="dark_theme">Mørk drakt</string>
     <string name="use_device_theme">Bruk enhetsdrakten</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -116,7 +116,6 @@
     <string name="get_new_updates">Ontvang nieuwe updates</string>
     <string name="coming_soon">Binnenkort beschikbaar</string>
     <string name="languages">Talen</string>
-    <string name="languages_desc">Engels, Chinees, meer</string>
     <string name="help_translate">Help met vertalen</string>
     <string name="tips_and_support">Tips &amp; ondersteuning</string>
     <string name="basic_colors">Basiskleuren</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -102,7 +102,6 @@
     <string name="interaction">Interakcje</string>
     <string name="interaction_desc">Strona startowa, reakcja na dotyk</string>
     <string name="languages">Język</string>
-    <string name="languages_desc">Angielski, Chiński i więcej </string>
     <string name="help_translate">Pomóż w tłumaczeniu</string>
     <string name="use_device_languages">Zgodny z systemem</string>
     <string name="tips_and_support">Porady i wsparcie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -81,7 +81,6 @@
     <string name="interaction">Interação</string>
     <string name="interaction_desc">Página Inicial, Feedback Tátil</string>
     <string name="languages">Idiomas</string>
-    <string name="languages_desc">Português, Inglês, Chinês, mais</string>
     <string name="help_translate">Ajude a traduzir</string>
     <string name="use_device_languages">Usar o idioma do dispositivo</string>
     <string name="welcome">Bem-vindo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -108,7 +108,6 @@
     <string name="color_and_style_desc">Tema, estilo de cores e tamanho da letra</string>
     <string name="interaction">Interação</string>
     <string name="languages">Idiomas</string>
-    <string name="languages_desc">Português, Inglês, Chinês, e mais</string>
     <string name="help_translate">Ajude a traduzir</string>
     <string name="use_device_languages">Utilizar o idioma do sistema</string>
     <string name="tips_and_support">Dicas e apoio</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3,7 +3,6 @@
     <string name="languages">Limbi</string>
     <string name="browse_tos_tips">Răsfoiți <i><u>Termenii și condițiile și Politica de confidențialitate</u></i></string>
     <string name="three_days">3z</string>
-    <string name="languages_desc">Română, Engleză, etc</string>
     <string name="primary_color">Culoare primară</string>
     <string name="icons_and_labels">Pictograme și etichete</string>
     <string name="wallpaper_colors">Culori de fundal</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -87,7 +87,6 @@
     <string name="interaction">Взаимодействие</string>
     <string name="interaction_desc">При запуске, тактильная обратная связь</string>
     <string name="languages">Локализация</string>
-    <string name="languages_desc">Английский, Китайский, и прочие</string>
     <string name="color_and_style">Цвет &amp; стиль</string>
     <string name="subhead">Подзаголовок</string>
     <string name="use_app_theme">Использовать тему устройства</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -70,7 +70,6 @@
     <string name="accounts_desc">Miestne, FreshRSS</string>
     <string name="color_and_style">Farba a štýl</string>
     <string name="color_and_style_desc">Téma, farebný štýl, veľkosť písma</string>
-    <string name="languages_desc">Angličtina, čínština a ďalšie</string>
     <string name="languages">Jazyky</string>
     <string name="help_translate">Pomôžte s prekladom</string>
     <string name="use_device_languages">Použiť jazyk zariadenia</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -164,7 +164,6 @@
     <string name="yesterday">Včeraj</string>
     <string name="mark_as_starred">Dodaj med priljubljene</string>
     <string name="unsubscribe_tips">Odjavite se od \"%1$s\" in izbrišite vse arhivirane novice iz tega vira</string>
-    <string name="languages_desc">angleščina, kitajščina, več</string>
     <string name="group_option_tips">Naslednje možnosti veljajo za vse vire v tej skupini</string>
     <string name="welcome">Dobrodošli</string>
     <string name="mark_as_read">Označi kot prebrano</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -3,7 +3,6 @@
     <string name="languages">Језици</string>
     <string name="browse_tos_tips">Погледајте <i><u>Услове коришћења и Политику приватности</u></i></string>
     <string name="three_days">3д</string>
-    <string name="languages_desc">енглески, кинески, остали</string>
     <string name="primary_color">Примарне боје</string>
     <string name="icons_and_labels">Иконице и ознаке</string>
     <string name="wallpaper_colors">Боје позадине</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -185,7 +185,6 @@
     <string name="clear_articles_group_tips">Rensa alla arkiverade artiklar i gruppen \"%1$s\".</string>
     <string name="tips_and_support">Råd &amp; hjälp</string>
     <string name="get_new_updates">Hämta nya uppdateringar</string>
-    <string name="languages_desc">Engelska, Kinesiska, ytterligare</string>
     <string name="tips_and_support_desc">Om, öppen källkodlicenser</string>
     <string name="use_device_languages">Använd enhetens språk</string>
     <string name="terms_of_service">Tjänstevillkor</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -170,7 +170,6 @@
     <string name="use_device_theme">Cihaz temasını kullan</string>
     <string name="interaction_desc">İlk sayfa, haptik geribildirim</string>
     <string name="primary_color_hint">#666666 veya 666666 gibi</string>
-    <string name="languages_desc">İngilizce, Çince, daha fazlası</string>
     <string name="help_translate">Çeviriye yardım et</string>
     <string name="primary_color">Ana Renk</string>
     <string name="update">Güncelle</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -74,7 +74,6 @@
     <string name="mark_as_starred">Позначити як Обране</string>
     <string name="mark_as_read_one_day">Позначити як прочитане більше 1 дня</string>
     <string name="mark_as_read_seven_days">Позначити як прочитане більше 7 днів тому</string>
-    <string name="languages_desc">Англійська, Китайська, інші</string>
     <string name="welcome">Ласкаво Просимо</string>
     <string name="tips_and_support_desc">Про застосунок, ліцензії з відкритим кодом</string>
     <string name="tos_tips">Будь ласка, прочитайте та прийміть Умови надання послуг та Політику конфіденційності, щоб продовжити.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -81,7 +81,6 @@
     <string name="coming_soon">Sẽ sớm ra mắt</string>
     <string name="accounts">Tài khoản</string>
     <string name="accounts_desc">Điện thoại, FreshRSS</string>
-    <string name="languages_desc">Anh, Việt, Trung và hơn nữa</string>
     <string name="help_translate">Giúp dịch</string>
     <string name="use_device_languages">Dùng ngôn ngữ thiết bị</string>
     <string name="tips_and_support">Mẹo &amp; hỗ trợ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -97,7 +97,6 @@
     <string name="interaction">交互</string>
     <string name="interaction_desc">初始页面、触感反馈</string>
     <string name="languages">语言</string>
-    <string name="languages_desc">英语、简体中文、更多</string>
     <string name="use_device_languages">跟随系统设置</string>
     <string name="help_translate">帮助我们翻译</string>
     <string name="tips_and_support">提示和支持</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -96,7 +96,6 @@
     <string name="interaction">互動</string>
     <string name="interaction_desc">起始頁面、觸覺回饋</string>
     <string name="languages">語言</string>
-    <string name="languages_desc">英文、中文、更多</string>
     <string name="use_device_languages">使用裝置語言</string>
     <string name="help_translate">協助翻譯</string>
     <string name="tips_and_support">提示和支援</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -443,5 +443,4 @@
     <string name="import_from_json">Import from JSON</string>
     <string name="export_as_json">Export as JSON</string>
     <string name="invalid_json_file_warning">This file may not be a valid JSON file. Importing it could potentially corrupt the app and result in the loss of current preferences. Are you sure you want to proceed?</string>
-    <string name="languages_desc">English, Chinese, and more</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -443,4 +443,5 @@
     <string name="import_from_json">Import from JSON</string>
     <string name="export_as_json">Export as JSON</string>
     <string name="invalid_json_file_warning">This file may not be a valid JSON file. Importing it could potentially corrupt the app and result in the loss of current preferences. Are you sure you want to proceed?</string>
+    <string name="languages_desc">English, Chinese, and more</string>
 </resources>


### PR DESCRIPTION
This removes the annoying warning during compilation.