### PR TITLE
fix(ui): Prevent text from being cut off in banner

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/base/Banner.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/Banner.kt
@@ -44,7 +44,7 @@ fun Banner(
     Surface(
         modifier = modifier
             .fillMaxWidth()
-            .height(if (!desc.isNullOrBlank()) 88.dp else Dp.Unspecified),
+            .height(Dp.Unspecified),
         color = Color.Unspecified,
     ) {
         Row(
@@ -57,7 +57,7 @@ fun Banner(
                     view.playSoundEffect(SoundEffectConstants.CLICK)
                     onClick()
                 }
-                .padding(16.dp, 20.dp),
+                .padding(16.dp, 15.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             icon?.let { icon ->

--- a/app/src/main/java/me/ash/reader/ui/component/base/DisplayText.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/DisplayText.kt
@@ -1,5 +1,6 @@
 package me.ash.reader.ui.component.base
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -16,6 +17,7 @@ fun DisplayText(
     modifier: Modifier = Modifier,
     text: String,
     desc: String,
+    onTextClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -28,9 +30,7 @@ fun DisplayText(
             )
     ) {
         Text(
-            // modifier = Modifier
-            //     .height(44.dp),
-            //     .animateContentSize(tween()),
+            modifier = Modifier.clickable { onTextClick() },
             text = text,
             style = MaterialTheme.typography.displaySmall,
             color = MaterialTheme.colorScheme.onSurface,
@@ -39,7 +39,6 @@ fun DisplayText(
         )
         RYExtensibleVisibility(visible = desc.isNotEmpty()) {
             Text(
-                modifier = Modifier.height(16.dp),
                 text = desc,
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.outline.copy(alpha = 0.7f),

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
@@ -203,12 +203,9 @@ fun FeedsPage(
             ) {
                 item {
                     DisplayText(
-                        modifier = Modifier.clickable {
-                            accountTabVisible = true
-                        },
                         text = feedsUiState.account?.name ?: "",
                         desc = if (isSyncing) stringResource(R.string.syncing) else "",
-                    )
+                    ) { accountTabVisible = true }
                 }
                 item {
                     Banner(


### PR DESCRIPTION
Closes https://github.com/Ashinch/ReadYou/issues/685.
Removed the fixed height of the banner and adjusted padding to compensate. Fix cut synchronization text as well.

<details>

![Screenshot_20240612_113851](https://github.com/Ashinch/ReadYou/assets/116089283/b57572a2-2bb3-4acb-a3f7-c061a6610d56)
<\details>