### PR TITLE
Refactor of RYScaffold to use TopAppBar with scrolling behaviour

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/base/RYScaffold.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/RYScaffold.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -38,6 +39,7 @@ fun RYScaffold(
 
     Scaffold(
         modifier = modifier
+            .fillMaxSize()
             .background(
                 MaterialTheme.colorScheme.surfaceColorAtElevation(
                     topBarTonalElevation,

--- a/app/src/main/java/me/ash/reader/ui/component/base/RYScaffold.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/RYScaffold.kt
@@ -1,14 +1,19 @@
 package me.ash.reader.ui.component.base
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import me.ash.reader.ui.ext.surfaceColorAtElevation
@@ -23,11 +28,14 @@ fun RYScaffold(
     containerTonalElevation: Dp = 0.dp,
     navigationIcon: (@Composable () -> Unit)? = null,
     actions: (@Composable RowScope.() -> Unit)? = null,
-    topBar: (@Composable () -> Unit)? = null,
     bottomBar: (@Composable () -> Unit)? = null,
     floatingActionButton: (@Composable () -> Unit)? = null,
     content: @Composable () -> Unit = {},
+    title: @Composable () -> String,
+    appBarOnClick: (() -> Unit)? = null
 ) {
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
+
     Scaffold(
         modifier = modifier
             .background(
@@ -35,24 +43,27 @@ fun RYScaffold(
                     topBarTonalElevation,
                     color = containerColor
                 )
-            ),
+            )
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
             containerTonalElevation,
             color = containerColor
         ) onDark MaterialTheme.colorScheme.surface,
         topBar = {
-            if (topBar != null) topBar() else if (navigationIcon != null || actions != null) {
-                TopAppBar(
-                    title = {},
-                    navigationIcon = { navigationIcon?.invoke() },
-                    actions = { actions?.invoke(this) },
-                    colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
-                            topBarTonalElevation
-                        ),
-                    )
-                )
-            }
+            LargeTopAppBar(
+                modifier = Modifier.clickable(
+                    onClick = { appBarOnClick?.invoke() },
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                ),
+                title = { Text(text=title.invoke(), maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                navigationIcon = { navigationIcon?.invoke() },
+                actions = { actions?.invoke(this) },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(topBarTonalElevation)
+                ),
+                scrollBehavior = scrollBehavior
+            )
         },
         content = {
             Column {

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.SwitchAccount
 import androidx.compose.material.icons.rounded.UnfoldLess
 import androidx.compose.material.icons.rounded.UnfoldMore
 import androidx.compose.material.rememberModalBottomSheetState
@@ -239,6 +240,13 @@ fun FeedsPage(
                     }
                 },
                 actions = {
+                    FeedbackIconButton(
+                        imageVector = Icons.Rounded.SwitchAccount,
+                        contentDescription = stringResource(R.string.switch_account),
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    ) {
+                        accountTabVisible = true
+                    }
                     if (subscribeViewModel.rssService.get().addSubscription) {
                         FeedbackIconButton(
                             imageVector = Icons.Rounded.Add,

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -212,57 +213,42 @@ fun FeedsPage(
     RYScaffold(
         topBarTonalElevation = topBarTonalElevation.value.dp,
         containerTonalElevation = groupListTonalElevation.value.dp,
-        topBar = {
-            TopAppBar(
-                modifier = Modifier.clickable(
-                    onClick = {
-                        scope.launch {
-                            if (listState.firstVisibleItemIndex != 0) {
-                                listState.animateScrollToItem(0)
-                            }
-                        }
-                    },
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() }
-                ),
-                title = {},
-                navigationIcon = {
-                    FeedbackIconButton(
-                        modifier = Modifier.size(20.dp),
-                        imageVector = Icons.Outlined.Settings,
-                        contentDescription = stringResource(R.string.settings),
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        showBadge = newVersion.whetherNeedUpdate(currentVersion, skipVersion),
-                    ) {
-                        navController.navigate(RouteName.SETTINGS) {
-                            launchSingleTop = true
-                        }
-                    }
-                },
-                actions = {
-                    FeedbackIconButton(
-                        imageVector = Icons.Rounded.SwitchAccount,
-                        contentDescription = stringResource(R.string.switch_account),
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    ) {
-                        accountTabVisible = true
-                    }
-                    if (subscribeViewModel.rssService.get().addSubscription) {
-                        FeedbackIconButton(
-                            imageVector = Icons.Rounded.Add,
-                            contentDescription = stringResource(R.string.subscribe),
-                            tint = MaterialTheme.colorScheme.onSurface,
-                        ) {
-                            subscribeViewModel.showDrawer()
-                        }
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
-                        topBarTonalElevation.value.dp
-                    ),
-                )
-            )
+        title = { feedsUiState.account?.name ?: "Foobar" },
+        appBarOnClick = { scope.launch {
+            if (listState.firstVisibleItemIndex != 0) {
+                listState.animateScrollToItem(0)
+            }
+        } },
+        navigationIcon = {
+            FeedbackIconButton(
+                modifier = Modifier.size(20.dp),
+                imageVector = Icons.Outlined.Settings,
+                contentDescription = stringResource(R.string.settings),
+                tint = MaterialTheme.colorScheme.onSurface,
+                showBadge = newVersion.whetherNeedUpdate(currentVersion, skipVersion),
+            ) {
+                navController.navigate(RouteName.SETTINGS) {
+                    launchSingleTop = true
+                }
+            }
+        },
+        actions = {
+            FeedbackIconButton(
+                imageVector = Icons.Rounded.SwitchAccount,
+                contentDescription = stringResource(R.string.switch_account),
+                tint = MaterialTheme.colorScheme.onSurface,
+            ) {
+                accountTabVisible = true
+            }
+            if (subscribeViewModel.rssService.get().addSubscription) {
+                FeedbackIconButton(
+                    imageVector = Icons.Rounded.Add,
+                    contentDescription = stringResource(R.string.subscribe),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                ) {
+                    subscribeViewModel.showDrawer()
+                }
+            }
         },
         content = {
             PullToRefreshBox(
@@ -274,12 +260,6 @@ fun FeedsPage(
                     modifier = Modifier.fillMaxSize(),
                     state = listState
                 ) {
-                    item {
-                        DisplayText(
-                            text = feedsUiState.account?.name ?: "",
-                            desc = "",
-                        ) { accountTabVisible = true }
-                    }
                     item {
                         Banner(
                             title = filterUiState.filter.toName(),

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -39,6 +40,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -234,79 +236,67 @@ fun FlowPage(
     RYScaffold(
         topBarTonalElevation = topBarTonalElevation.value.dp,
         containerTonalElevation = articleListTonalElevation.value.dp,
-        topBar = {
-            TopAppBar(
-                modifier = Modifier.clickable(
-                    onClick = {
-                        scope.launch {
-                            if (listState.firstVisibleItemIndex != 0) {
-                                listState.animateScrollToItem(0)
-                            }
-                        }
+        title = { when {
+                filterUiState.group != null -> filterUiState.group.name
+                filterUiState.feed != null -> filterUiState.feed.name
+                else -> filterUiState.filter.toName()
+            } },
+        appBarOnClick = {  scope.launch {
+                if (listState.firstVisibleItemIndex != 0) {
+                    listState.animateScrollToItem(0)
+                }
+            } },
+        navigationIcon = {
+            FeedbackIconButton(
+                imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                contentDescription = stringResource(R.string.back),
+                tint = MaterialTheme.colorScheme.onSurface
+            ) {
+                onSearch = false
+                if (navController.previousBackStackEntry == null) {
+                    navController.navigate(RouteName.FEEDS) {
+                        launchSingleTop = true
+                    }
+                } else {
+                    navController.popBackStack()
+                }
+            } },
+        actions = {
+            RYExtensibleVisibility(visible = !filterUiState.filter.isStarred()) {
+                FeedbackIconButton(
+                    imageVector = Icons.Rounded.DoneAll,
+                    contentDescription = stringResource(R.string.mark_all_as_read),
+                    tint = if (markAsRead) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
                     },
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() }
-                ),
-                title = {},
-                navigationIcon = {
-                    FeedbackIconButton(
-                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
-                        contentDescription = stringResource(R.string.back),
-                        tint = MaterialTheme.colorScheme.onSurface
-                    ) {
+                ) {
+                    scope.launch {
+                        if (flowUiState.listState.firstVisibleItemIndex != 0) {
+                            flowUiState.listState.animateScrollToItem(0)
+                        }
+                        markAsRead = !markAsRead
                         onSearch = false
-                        if (navController.previousBackStackEntry == null) {
-                            navController.navigate(RouteName.FEEDS) {
-                                launchSingleTop = true
-                            }
-                        } else {
-                            navController.popBackStack()
-                        }
                     }
+                }
+            }
+            FeedbackIconButton(
+                imageVector = Icons.Rounded.Search,
+                contentDescription = stringResource(R.string.search),
+                tint = if (onSearch) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurface
                 },
-                actions = {
-                    RYExtensibleVisibility(visible = !filterUiState.filter.isStarred()) {
-                        FeedbackIconButton(
-                            imageVector = Icons.Rounded.DoneAll,
-                            contentDescription = stringResource(R.string.mark_all_as_read),
-                            tint = if (markAsRead) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurface
-                            },
-                        ) {
-                            scope.launch {
-                                if (flowUiState.listState.firstVisibleItemIndex != 0) {
-                                    flowUiState.listState.animateScrollToItem(0)
-                                }
-                                markAsRead = !markAsRead
-                                onSearch = false
-                            }
-                        }
+            ) {
+                scope.launch {
+                    if (flowUiState.listState.firstVisibleItemIndex != 0) {
+                        flowUiState.listState.animateScrollToItem(0)
                     }
-                    FeedbackIconButton(
-                        imageVector = Icons.Rounded.Search,
-                        contentDescription = stringResource(R.string.search),
-                        tint = if (onSearch) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurface
-                        },
-                    ) {
-                        scope.launch {
-                            if (flowUiState.listState.firstVisibleItemIndex != 0) {
-                                flowUiState.listState.animateScrollToItem(0)
-                            }
-                            onSearch = !onSearch
-                        }
-                    }
-                }, colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
-                        topBarTonalElevation.value.dp
-                    ),
-                )
-            )
-        },
+                    onSearch = !onSearch
+                }
+            } },
         content = {
             PullToRefreshBox(
                 state = syncingState,
@@ -318,15 +308,6 @@ fun FlowPage(
                     state = listState,
                 ) {
                     item {
-                        DisplayText(
-                            modifier = Modifier.padding(start = if (articleListFeedIcon.value) 30.dp else 0.dp),
-                            text = when {
-                                filterUiState.group != null -> filterUiState.group.name
-                                filterUiState.feed != null -> filterUiState.feed.name
-                                else -> filterUiState.filter.toName()
-                            },
-                            desc = "",
-                        )
                         RYExtensibleVisibility(visible = markAsRead) {
                             Spacer(modifier = Modifier.height((56 + 24 + 10).dp))
                         }

--- a/app/src/main/java/me/ash/reader/ui/page/settings/SettingsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/SettingsPage.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.outlined.TouchApp
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -66,11 +68,9 @@ fun SettingsPage(
                 navController.popBackStack()
             }
         },
+        title = { stringResource(R.string.settings) },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.settings), desc = "")
-                }
                 item {
                     Box {
                         if (newVersion.whetherNeedUpdate(currentVersion, skipVersion)) {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountDetailsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountDetailsPage.kt
@@ -116,6 +116,7 @@ fun AccountDetailsPage(
     }
 
     RYScaffold(
+        title = { selectedAccount?.type?.toDesc(context) ?: "" },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -140,7 +141,6 @@ fun AccountDetailsPage(
         content = {
             LazyColumn {
                 item {
-                    DisplayText(text = selectedAccount?.type?.toDesc(context) ?: "", desc = "")
                     Spacer(modifier = Modifier.height(16.dp))
                 }
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountsPage.kt
@@ -35,6 +35,7 @@ fun AccountsPage(
     val accounts = viewModel.accounts.collectAsStateValue(initial = emptyList())
 
     RYScaffold(
+        title = { stringResource(R.string.accounts) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -48,7 +49,6 @@ fun AccountsPage(
         content = {
             LazyColumn {
                 item {
-                    DisplayText(text = stringResource(R.string.accounts), desc = "")
                     Spacer(modifier = Modifier.height(16.dp))
                     Subtitle(
                         modifier = Modifier.padding(horizontal = 24.dp),

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AddAccountsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AddAccountsPage.kt
@@ -35,6 +35,7 @@ fun AddAccountsPage(
     val context = LocalContext.current
 
     RYScaffold(
+        title = { stringResource(R.string.add_accounts) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -48,7 +49,6 @@ fun AddAccountsPage(
         content = {
             LazyColumn {
                 item {
-                    DisplayText(text = stringResource(R.string.add_accounts), desc = "")
                     Spacer(modifier = Modifier.height(16.dp))
                 }
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/ColorAndStylePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/ColorAndStylePage.kt
@@ -110,6 +110,7 @@ fun ColorAndStylePage(
     }
 
     RYScaffold(
+        title = { stringResource(R.string.color_and_style) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -122,9 +123,6 @@ fun ColorAndStylePage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.color_and_style), desc = "")
-                }
                 item {
                     Row(
                         modifier = Modifier

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/DarkThemePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/DarkThemePage.kt
@@ -34,6 +34,7 @@ fun DarkThemePage(
     val scope = rememberCoroutineScope()
 
     RYScaffold(
+        title = { stringResource(R.string.dark_theme) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -46,9 +47,6 @@ fun DarkThemePage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.dark_theme), desc = "")
-                }
                 item {
                     DarkThemePreference.values.map {
                         SettingItem(

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPageStylePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPageStylePage.kt
@@ -46,6 +46,7 @@ fun FeedsPageStylePage(
     var filterBarPaddingValue: Int? by remember { mutableStateOf(filterBarPadding) }
 
     RYScaffold(
+        title = { stringResource(R.string.feeds_page) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -58,9 +59,6 @@ fun FeedsPageStylePage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.feeds_page), desc = "")
-                }
 
                 // Preview
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/flow/FlowPageStylePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/flow/FlowPageStylePage.kt
@@ -63,11 +63,9 @@ fun FlowPageStylePage(
                 navController.popBackStack()
             }
         },
+        title = { stringResource(R.string.flow_page) },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.flow_page), desc = "")
-                }
 
                 // Preview
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/BionicReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/BionicReadingPage.kt
@@ -55,6 +55,7 @@ fun BionicReadingPage(
     val bionicReading = LocalReadingBionicReading.current
 
     RYScaffold(
+        title = { stringResource(R.string.bionic_reading) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -67,9 +68,6 @@ fun BionicReadingPage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.bionic_reading), desc = "")
-                }
 
                 // Preview
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingDarkThemePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingDarkThemePage.kt
@@ -33,6 +33,7 @@ fun ReadingDarkThemePage(
     val scope = rememberCoroutineScope()
 
     RYScaffold(
+        title = { stringResource(R.string.dark_theme) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -45,9 +46,6 @@ fun ReadingDarkThemePage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.dark_theme), desc = "")
-                }
                 item {
                     ReadingDarkThemePreference.values.map {
                         SettingItem(

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingImagePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingImagePage.kt
@@ -61,6 +61,7 @@ fun ReadingImagePage(
     var horizontalPaddingValue: Int? by remember { mutableStateOf(horizontalPadding) }
 
     RYScaffold(
+        title = { stringResource(R.string.images) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -73,9 +74,6 @@ fun ReadingImagePage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.images), desc = "")
-                }
 
                 // Preview
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingStylePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingStylePage.kt
@@ -97,6 +97,7 @@ fun ReadingStylePage(
     }
 
     RYScaffold(
+        title = { stringResource(R.string.reading_page) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -109,9 +110,6 @@ fun ReadingStylePage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.reading_page), desc = "")
-                }
 
                 // Preview
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingTextPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingTextPage.kt
@@ -83,6 +83,7 @@ fun ReadingTextPage(
     var horizontalPaddingValue: Int? by remember { mutableStateOf(horizontalPadding) }
 
     RYScaffold(
+        title = { stringResource(R.string.text) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -95,9 +96,6 @@ fun ReadingTextPage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.text), desc = "")
-                }
 
                 // Preview
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingTitlePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingTitlePage.kt
@@ -8,12 +8,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import me.ash.reader.R
@@ -50,12 +52,9 @@ fun ReadingTitlePage(
                 navController.popBackStack()
             }
         },
+        title = { stringResource(R.string.title) },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.title), desc = "")
-                }
-
                 // Preview
                 item {
                     Row(

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingVideoPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingVideoPage.kt
@@ -35,6 +35,7 @@ fun ReadingVideoPage(
     val scope = rememberCoroutineScope()
 
     RYScaffold(
+        title = { stringResource(R.string.videos) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -47,9 +48,6 @@ fun ReadingVideoPage(
         },
         content = {
             LazyColumn {
-                item {
-                    DisplayText(text = stringResource(R.string.videos), desc = "")
-                }
 
                 // Preview
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/interaction/InteractionPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/interaction/InteractionPage.kt
@@ -75,6 +75,7 @@ fun InteractionPage(
     var sharedContentDialogVisible by remember { mutableStateOf(false) }
 
     RYScaffold(
+        title = { stringResource(R.string.interaction) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -88,7 +89,6 @@ fun InteractionPage(
         content = {
             LazyColumn {
                 item {
-                    DisplayText(text = stringResource(R.string.interaction), desc = "")
                     Spacer(modifier = Modifier.height(16.dp))
                 }
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/languages/LanguagesPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/languages/LanguagesPage.kt
@@ -47,6 +47,7 @@ fun LanguagesPage(
     val scope = rememberCoroutineScope()
 
     RYScaffold(
+        title = { stringResource(R.string.languages) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(
@@ -60,7 +61,6 @@ fun LanguagesPage(
         content = {
             LazyColumn {
                 item(key = languages.value) {
-                    DisplayText(text = stringResource(R.string.languages), desc = "")
                     Spacer(modifier = Modifier.height(16.dp))
                     Banner(
                         title = stringResource(R.string.help_translate),

--- a/app/src/main/java/me/ash/reader/ui/page/settings/tips/LicenseListPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/tips/LicenseListPage.kt
@@ -32,6 +32,7 @@ fun LicenseListPage(
     val context = LocalContext.current
 
     RYScaffold(
+        title = { stringResource(R.string.open_source_licenses) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(

--- a/app/src/main/java/me/ash/reader/ui/page/settings/tips/TipsAndSupportPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/tips/TipsAndSupportPage.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -115,12 +116,10 @@ fun TipsAndSupportPage(
             }
         },
         content = {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.SpaceAround,
-            ) {
-                item {
+            Column ( modifier = Modifier.fillMaxWidth(),
+                     horizontalAlignment = Alignment.CenterHorizontally,
+                     verticalArrangement = Arrangement.spacedBy(48.dp) ) {
+                Row {
                     Column(
                         modifier = Modifier.pointerInput(Unit) {
                             detectTapGestures(
@@ -155,7 +154,7 @@ fun TipsAndSupportPage(
                             )
                         },
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center,
+                        verticalArrangement = Arrangement.spacedBy(48.dp),
                     ) {
                         Box(
                             modifier = Modifier
@@ -179,7 +178,6 @@ fun TipsAndSupportPage(
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface alwaysLight true),
                             )
                         }
-                        Spacer(modifier = Modifier.height(48.dp))
                         BadgedBox(
                             badge = {
                                 Badge(
@@ -198,53 +196,44 @@ fun TipsAndSupportPage(
                         }
                     }
                 }
-                item {
-                    Spacer(modifier = Modifier.height(48.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically,
+                Row ( modifier = Modifier.fillMaxWidth(),
+                      horizontalArrangement = Arrangement.spacedBy(16.dp, alignment = Alignment.CenterHorizontally),) {
+
+                    // Sponsor
+                    RoundIconButton(RoundIconButtonType.Sponsor(
+                        backgroundColor = MaterialTheme.colorScheme.tertiaryContainer alwaysLight true,
                     ) {
-                        // Sponsor
-                        RoundIconButton(RoundIconButtonType.Sponsor(
-                            backgroundColor = MaterialTheme.colorScheme.tertiaryContainer alwaysLight true,
-                        ) {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                            view.playSoundEffect(SoundEffectConstants.CLICK)
-                            context.showToast(context.getString(R.string.coming_soon))
-                        })
-                        Spacer(modifier = Modifier.width(16.dp))
+                        view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                        view.playSoundEffect(SoundEffectConstants.CLICK)
+                        context.showToast(context.getString(R.string.coming_soon))
+                    })
 
-                        // GitHub
-                        RoundIconButton(RoundIconButtonType.GitHub(
-                            backgroundColor = MaterialTheme.colorScheme.primaryContainer alwaysLight true,
-                        ) {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                            view.playSoundEffect(SoundEffectConstants.CLICK)
-                            context.openURL(context.getString(R.string.github_link), OpenLinkPreference.AutoPreferCustomTabs)
-                        })
-                        Spacer(modifier = Modifier.width(16.dp))
+                    // GitHub
+                    RoundIconButton(RoundIconButtonType.GitHub(
+                        backgroundColor = MaterialTheme.colorScheme.primaryContainer alwaysLight true,
+                    ) {
+                        view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                        view.playSoundEffect(SoundEffectConstants.CLICK)
+                        context.openURL(context.getString(R.string.github_link), OpenLinkPreference.AutoPreferCustomTabs)
+                    })
 
-                        // Telegram
-                        RoundIconButton(RoundIconButtonType.Telegram(
-                            backgroundColor = MaterialTheme.colorScheme.primaryContainer alwaysLight true,
-                        ) {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                            view.playSoundEffect(SoundEffectConstants.CLICK)
-                            context.openURL(context.getString(R.string.telegram_link), OpenLinkPreference.AutoPreferCustomTabs)
-                        })
-                        Spacer(modifier = Modifier.width(16.dp))
+                    // Telegram
+                    RoundIconButton(RoundIconButtonType.Telegram(
+                        backgroundColor = MaterialTheme.colorScheme.primaryContainer alwaysLight true,
+                    ) {
+                        view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                        view.playSoundEffect(SoundEffectConstants.CLICK)
+                        context.openURL(context.getString(R.string.telegram_link), OpenLinkPreference.AutoPreferCustomTabs)
+                    })
 
-                        // Help
-                        RoundIconButton(RoundIconButtonType.Help(
-                            backgroundColor = MaterialTheme.colorScheme.secondaryContainer alwaysLight true,
-                        ) {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                            view.playSoundEffect(SoundEffectConstants.CLICK)
-                            context.openURL(context.getString(R.string.wiki_link), OpenLinkPreference.AutoPreferCustomTabs)
-                        })
-                    }
-                    Spacer(modifier = Modifier.height(48.dp))
+                    // Help
+                    RoundIconButton(RoundIconButtonType.Help(
+                        backgroundColor = MaterialTheme.colorScheme.secondaryContainer alwaysLight true,
+                    ) {
+                        view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                        view.playSoundEffect(SoundEffectConstants.CLICK)
+                        context.openURL(context.getString(R.string.wiki_link), OpenLinkPreference.AutoPreferCustomTabs)
+                    })
                 }
             }
         }

--- a/app/src/main/java/me/ash/reader/ui/page/settings/tips/TipsAndSupportPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/tips/TipsAndSupportPage.kt
@@ -91,6 +91,7 @@ fun TipsAndSupportPage(
     }
 
     RYScaffold(
+        title = { stringResource(R.string.tips_and_support) },
         containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
         navigationIcon = {
             FeedbackIconButton(

--- a/app/src/main/java/me/ash/reader/ui/page/settings/troubleshooting/TroubleshootingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/troubleshooting/TroubleshootingPage.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -95,10 +96,10 @@ fun TroubleshootingPage(
                 navController.popBackStack()
             }
         },
+        title={ stringResource(R.string.troubleshooting) },
         content = {
             LazyColumn {
                 item {
-                    DisplayText(text = stringResource(R.string.troubleshooting), desc = "")
                     Spacer(modifier = Modifier.height(16.dp))
                     Banner(
                         title = stringResource(R.string.bug_report),

--- a/app/src/main/java/me/ash/reader/ui/page/startup/StartupPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/startup/StartupPage.kt
@@ -51,13 +51,11 @@ fun StartupPage(
     var tosVisible by remember { mutableStateOf(false) }
 
     RYScaffold(
+        title = { stringResource(R.string.welcome) },
         content = {
-            LazyColumn(
-                modifier = Modifier.navigationBarsPadding(),
-            ) {
+            LazyColumn {
                 item {
                     Spacer(modifier = Modifier.height(64.dp))
-                    DisplayText(text = stringResource(R.string.welcome), desc = "")
                 }
                 item {
                     Spacer(modifier = Modifier.height(16.dp))
@@ -85,7 +83,6 @@ fun StartupPage(
                             ),
                         )
                     }
-                    Spacer(modifier = Modifier.height(100.dp))
                 }
             }
         },

--- a/app/src/main/java/me/ash/reader/ui/page/startup/StartupPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/startup/StartupPage.kt
@@ -1,5 +1,7 @@
 package me.ash.reader.ui.page.startup
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -53,37 +55,28 @@ fun StartupPage(
     RYScaffold(
         title = { stringResource(R.string.welcome) },
         content = {
-            LazyColumn {
-                item {
-                    Spacer(modifier = Modifier.height(64.dp))
-                }
-                item {
-                    Spacer(modifier = Modifier.height(16.dp))
-                    DynamicSVGImage(
-                        modifier = Modifier.padding(horizontal = 60.dp),
-                        svgImageString = SVGString.WELCOME,
-                        contentDescription = stringResource(R.string.color_and_style),
+            Column (verticalArrangement = Arrangement.Center) {
+                DynamicSVGImage(
+                    svgImageString = SVGString.WELCOME,
+                    contentDescription = stringResource(R.string.color_and_style),
+                )
+
+                Tips(
+                    text = stringResource(R.string.tos_tips),
+                )
+
+                TextButton(
+                    modifier = Modifier.padding(start = 12.dp),
+                    onClick = { tosVisible = true }
+                ) {
+                    HtmlText(
+                        text = stringResource(R.string.browse_tos_tips),
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            color = MaterialTheme.colorScheme.outline,
+                        ),
                     )
                 }
-                item {
-                    Tips(
-                        modifier = Modifier.padding(top = 40.dp),
-                        text = stringResource(R.string.tos_tips),
-                    )
-                }
-                item {
-                    TextButton(
-                        modifier = Modifier.padding(horizontal = 12.dp),
-                        onClick = { tosVisible = true }
-                    ) {
-                        HtmlText(
-                            text = stringResource(R.string.browse_tos_tips),
-                            style = MaterialTheme.typography.bodySmall.copy(
-                                color = MaterialTheme.colorScheme.outline,
-                            ),
-                        )
-                    }
-                }
+
             }
         },
         bottomBar = null,


### PR DESCRIPTION
This is a small refactor of the RYScaffold to use a TopAppBar with nested scrolling instead of an in-content header.

This also moves the Switch Account action from being on the Feeds page header text on-click to an actual dedicated button. I think this is more discoverable b/c it is not obvious how to switch accounts from the Feeds page if you don't already know about this feature.

Jump to top is also preserved for the browsing pages via an on-click callback on RYScaffold's new TopAppBar. This is basically what it was before, just move around a little.

Note that there is some goofyness around pages that are smaller that the viewport. Ideally I'd like them to not be scrollable at all but, I was not able to figure out how to do that elegantly. I could always pass down a boolean flag to RYScaffold to turn the scrolling off but, that feels nasty. If you have any ideas, let me know.

## Before
![before - unscrolled](https://github.com/user-attachments/assets/57268208-0910-447f-aebe-76f050a7c470)
![before - scrolled](https://github.com/user-attachments/assets/f8b577d9-56f6-4b23-9738-fab8bc37725f)

## After
![after - unscrolled](https://github.com/user-attachments/assets/b971c904-fb3c-4f0e-a892-955788714f6c)
![after - scrolled](https://github.com/user-attachments/assets/d4aeaca4-dd12-43fb-9557-bffaad74cda0)

