### PR TITLE
Fix new group button alignment

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedOptionView.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedOptionView.kt
@@ -215,7 +215,12 @@ private fun AddToGroup(
                 }
                 Spacer(modifier = Modifier.width(10.dp))
             }
-            item { NewGroupButton(onAddNewGroup) }
+            item {
+                NewGroupButton(
+                    onAddNewGroup,
+                    Modifier,
+                )
+            }
         }
     } else {
         FlowRow(
@@ -231,15 +236,18 @@ private fun AddToGroup(
                     onGroupClick(it.id)
                 }
             }
-            NewGroupButton(onAddNewGroup)
+            NewGroupButton(
+                onAddNewGroup,
+                Modifier.align(Alignment.CenterVertically),
+            )
         }
     }
 }
 
 @Composable
-private fun NewGroupButton(onAddNewGroup: () -> Unit) {
+private fun NewGroupButton(onAddNewGroup: () -> Unit, modifier: Modifier) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .size(36.dp)
             .clip(CircleShape)
             .background(MaterialTheme.colorScheme.surfaceVariant)


### PR DESCRIPTION
The alignment for the new group button is wrong in the feed menu. This PR fixes it so that the button is in-line vertically with the other buttons.

Before:
![before](https://github.com/user-attachments/assets/d04ab683-4dc7-4103-869f-7c652fa10123)

After:
![after](https://github.com/user-attachments/assets/69b224ea-e0f0-41da-8400-e5b7a42d7ad4)
