### PR TITLE
Fix group padding on the 'Feeds' page

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
@@ -334,9 +334,8 @@ fun FeedsPage(
                     itemsIndexed(groupWithFeedList) { index, groupWithFeed ->
                         when (groupWithFeed) {
                             is GroupFeedsView.Group -> {
-                                Spacer(modifier = Modifier.height(16.dp))
-
                                 if (groupWithFeed.group.id != defaultGroupId || groupWithFeed.group.feeds > 0) {
+                                    Spacer(modifier = Modifier.height(16.dp))
                                     GroupItem(
                                         isExpanded = {
                                             groupsVisible.getOrPut(


### PR DESCRIPTION
The group spacing is incorrect on the 'All' tab of the Feeds page. A 16dp spacer is supposed to be added for each visible feed. Yet if the user has no feeds in their Default group and the group is hidden, a spacer is added nonetheless.

I've included some screenshots below. At the top, you can see what the 'Unread' and 'All' pages looked like before. At the bottom is what it is supposed to look like, with the inconsistent padding removed.
![Comparison](https://github.com/user-attachments/assets/0f57a919-ed10-4a71-b860-d8ad1ce04468)
