### PR TITLE
Fix the crash that occurs when adding a feed without an icon

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/rss/FetchedFeed.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/FetchedFeed.kt
@@ -20,9 +20,9 @@ import rust.nostr.sdk.getNip05Profile
 import java.time.Duration
 
 sealed interface FetchedFeed {
-    fun getIconLink(): String
+    fun getIconLink(): String?
     //The function below is for compatibility with SyndFeed
-    fun getIconUrl(): String
+    fun getIconUrl(): String?
     fun getFeedLink(): String
     var title: String
     fun getFeedAuthor(): String
@@ -33,11 +33,11 @@ class SyndFeedDelegate(
     private val syndFeed: SyndFeed
 ): FetchedFeed {
 
-    override fun getIconLink(): String {
+    override fun getIconLink(): String? {
         return syndFeed.icon.link
     }
 
-    override fun getIconUrl(): String {
+    override fun getIconUrl(): String? {
         return syndFeed.icon.url
     }
 


### PR DESCRIPTION
The commit https://github.com/Ashinch/ReadYou/commit/ec05bddba8e435482dadbda7d8ca645749e257ba introduced a regression where attempting to subscribe to a feed without a favicon will cause ReadYou to crash. The link to the icon should be set to null if one doesn't exist, just like it did before the commit.

I used the following feed to test this bug:
https://feeds.yle.fi/uutiset/v1/majorHeadlines/YLE_UUTISET.rss