### PR TITLE
Change launch mode to singleTop

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         <activity
             android:name=".infrastructure.android.MainActivity"
             android:exported="true"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.Reader">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This fixes an issue I had when using CustomTabs for external links, likely the same as #961. When closing the browser after opening a link, I was being sent back to the app launcher, when I expected to go back to the screen in Read You where I clicked the link. After some research, I found that according to https://developer.android.com/guide/topics/manifest/activity-element#lmode, the `singleInstance` launch mode does not allow launching other activities into MainActivity's Task. The CustomTabs activity would launch under a new foreground task, causing Android to destroy the original MainActivity task to free resources, which led to the observed behavior.

Changing MainActivity's launch mode to `singleTop` allows the CustomTabs to launch in the same task, keeping MainActivity alive and enabling the back button to function as expected.

Since this change affects how intents are handled, this PR also includes an override for onNewIntent to properly handle incoming feed links, as required by the `singleTop` mode according to the documentation. This works better than the listener used before, where adding a feed when the app was not already open did not open the subscribe dialog, but now it does. Notifications apparently work the same as before because `FLAG_ACTIVITY_NEW_TASK || FLAG_ACTIVITY_CLEAR_TASK` is used in NotificationHelper's intents.