### PR TITLE
Don't sync all feeds when in a group/feed

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -136,7 +136,7 @@ class FeverRssService @Inject constructor(
      * 3. Fetch the Fever articles
      * 4. Synchronize read/unread and starred/un-starred items
      */
-    override suspend fun sync(coroutineWorker: CoroutineWorker): ListenableWorker.Result =
+    override suspend fun sync(coroutineWorker: CoroutineWorker, group: String?, feed: String?): ListenableWorker.Result =
         supervisorScope {
             coroutineWorker.setProgress(SyncWorker.setIsSyncing(true))
 

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -217,7 +217,7 @@ class GoogleReaderRssService @Inject constructor(
      * @link https://github.com/bazqux/bazqux-api?tab=readme-ov-file
      * @link https://github.com/theoldreader/api
      */
-    override suspend fun sync(coroutineWorker: CoroutineWorker): ListenableWorker.Result =
+    override suspend fun sync(coroutineWorker: CoroutineWorker, group: String?, feed: String?): ListenableWorker.Result =
         supervisorScope {
             coroutineWorker.setProgress(SyncWorker.setIsSyncing(true))
 

--- a/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
@@ -25,7 +25,9 @@ class SyncWorker @AssistedInject constructor(
     override suspend fun doWork(): Result =
         withContext(Dispatchers.Default) {
             Log.i("RLog", "doWork: ")
-            rssService.get().sync(this@SyncWorker).also {
+            val group = inputData.getString("group")
+            val feed = inputData.getString("feed")
+            rssService.get().sync(this@SyncWorker, group, feed).also {
                 rssService.get().clearKeepArchivedArticles()
             }
         }
@@ -44,14 +46,19 @@ class SyncWorker @AssistedInject constructor(
         fun cancelPeriodicWork(workManager: WorkManager) {
             workManager.cancelUniqueWork(WORK_NAME_PERIODIC)
         }
-
         fun enqueueOneTimeWork(
             workManager: WorkManager,
+            group: String?,
+            feed: String?,
         ) {
+            val inputData = Data.Builder()
+                .putString("group", group)
+                .putString("feed", feed)
+                .build()
             workManager.enqueueUniqueWork(
                 WORK_NAME_ONETIME,
                 ExistingWorkPolicy.KEEP,
-                OneTimeWorkRequestBuilder<SyncWorker>().addTag(WORK_TAG).build()
+                OneTimeWorkRequestBuilder<SyncWorker>().setInputData(inputData).addTag(WORK_TAG).build()
             )
         }
 

--- a/app/src/main/java/me/ash/reader/ui/page/home/HomeViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/HomeViewModel.kt
@@ -50,7 +50,7 @@ class HomeViewModel @Inject constructor(
 
     fun sync() {
         applicationScope.launch(ioDispatcher) {
-            rssService.get().doSyncOneTime()
+            rssService.get().doSyncOneTime(null, null)
         }
     }
 

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeViewModel.kt
@@ -59,7 +59,7 @@ class SubscribeViewModel @Inject constructor(
     fun importFromInputStream(inputStream: InputStream) {
         applicationScope.launch {
             opmlService.saveToDatabase(inputStream)
-            rssService.get().doSyncOneTime()
+            rssService.get().doSyncOneTime(null, null)
         }
     }
 

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -161,8 +161,10 @@ fun FlowPage(
     val syncingScope = rememberCoroutineScope()
     val doSync: () -> Unit = {
         isSyncing = true
+        val group = filterUiState.group?.id
+        val feed = filterUiState.feed?.id
         syncingScope.launch {
-            flowViewModel.sync()
+            flowViewModel.sync(group, feed)
         }
     }
 
@@ -236,7 +238,6 @@ fun FlowPage(
             }
         }
     }
-
     LaunchedEffect(onSearch) {
         if (!onSearch) {
             keyboardController?.hide()

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowViewModel.kt
@@ -32,9 +32,9 @@ class FlowViewModel @Inject constructor(
     val flowUiState: StateFlow<FlowUiState> = _flowUiState.asStateFlow()
     val diffMap = mutableStateMapOf<String, Diff>()
 
-    fun sync() {
+    fun sync(group: String?, feed: String?) {
         applicationScope.launch(ioDispatcher) {
-            rssService.get().doSyncOneTime()
+            rssService.get().doSyncOneTime(group, feed)
         }
     }
 

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
@@ -105,7 +105,7 @@ class AccountViewModel @Inject constructor(
             try {
                 val rssService = rssService.get(addAccount.type.id)
                 if (rssService.validCredentials(account)) {
-                    rssService.doSyncOneTime()
+                    rssService.doSyncOneTime(null, null)
                     withContext(mainDispatcher) {
                         callback(addAccount, null)
                     }


### PR DESCRIPTION
To save bandwidth and make the syncing faster, only the feeds of the focused group should be synced. If the user has selected a feed, only that feed should be synced.

In my case syncing can take upwards of 5 seconds. I use the app for multiple tasks like following the news and subscribing to a couple of content creators on a video streaming platform. If I want to catch up with the latest news while out and about, it's unnecessary to sync all feeds.