### PR TITLE
Remove some non-determinism

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,10 @@ android {
     namespace = "me.ash.reader"
 }
 
+aboutLibraries {
+    excludeFields = arrayOf("generated")
+}
+
 dependencies {
     // AboutLibraries
     implementation(libs.aboutlibraries.core)


### PR DESCRIPTION
Your app is not built reproducible in F-Droid, but we continuously test older versions on https://verification.f-droid.org/ and would like more and more apps to become repro

Looking at the latest app report: https://verification.f-droid.org/packages/me.ash.reader/

We can fix it by disabling the generated entry, or upgrading the lib to 11.5.0 or later.

ref: mikepenz/AboutLibraries#784 (comment)

ref: https://github.com/mikepenz/AboutLibraries/releases/tag/11.5.0