### PR TITLE
fix: prefer HTTP header charset and fallback to UTF-8 when missing

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
@@ -49,9 +49,16 @@ constructor(
     suspend fun searchFeed(feedLink: String): SyndFeed {
         return withContext(ioDispatcher) {
             val response = response(okHttpClient, feedLink)
-        //    val contentType = response.header("Content-Type")
+            val contentType = response.header("Content-Type")
+            val httpContentType =
+                contentType?.let {
+                    if (it.contains("charset=", ignoreCase = true)) it
+                    else "$it; charset=UTF-8"
+                } ?: "text/xml; charset=UTF-8"
+
+
             response.body.byteStream().use { inputStream ->
-                SyndFeedInput().build(XmlReader(inputStream, Charsets.UTF_8.name())).also {
+                    SyndFeedInput().build(XmlReader(inputStream, httpContentType)).also {
                     it.icon = SyndImageImpl()
                     it.icon.link = queryRssIconLink(feedLink)
                     it.icon.url = it.icon.link
@@ -119,11 +126,18 @@ constructor(
         try {
             val accountId = context.currentAccountId
             val response = response(okHttpClient, feed.url)
-        //    val contentType = response.header("Content-Type")
+            val contentType = response.header("Content-Type")
+
+            val httpContentType =
+                contentType?.let {
+                    if (it.contains("charset=", ignoreCase = true)) it
+                    else "$it; charset=UTF-8"
+                } ?: "text/xml; charset=UTF-8"
+
             response.body.byteStream().use { inputStream ->
                 SyndFeedInput()
                     .apply { isPreserveWireFeed = true }
-                    .build(XmlReader(inputStream, Charsets.UTF_8.name()))
+                    .build(XmlReader(inputStream, httpContentType))
                     .entries
                     .asSequence()
                     .takeWhile { latestLink == null || latestLink != it.link }

--- a/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
@@ -49,9 +49,9 @@ constructor(
     suspend fun searchFeed(feedLink: String): SyndFeed {
         return withContext(ioDispatcher) {
             val response = response(okHttpClient, feedLink)
-            val contentType = response.header("Content-Type")
+        //    val contentType = response.header("Content-Type")
             response.body.byteStream().use { inputStream ->
-                SyndFeedInput().build(XmlReader(inputStream, contentType)).also {
+                SyndFeedInput().build(XmlReader(inputStream, Charsets.UTF_8.name())).also {
                     it.icon = SyndImageImpl()
                     it.icon.link = queryRssIconLink(feedLink)
                     it.icon.url = it.icon.link
@@ -119,11 +119,11 @@ constructor(
         try {
             val accountId = context.currentAccountId
             val response = response(okHttpClient, feed.url)
-            val contentType = response.header("Content-Type")
+        //    val contentType = response.header("Content-Type")
             response.body.byteStream().use { inputStream ->
                 SyndFeedInput()
                     .apply { isPreserveWireFeed = true }
-                    .build(XmlReader(inputStream, contentType))
+                    .build(XmlReader(inputStream, Charsets.UTF_8.name()))
                     .entries
                     .asSequence()
                     .takeWhile { latestLink == null || latestLink != it.link }


### PR DESCRIPTION
Fixes #1193

This fixes incorrectly decoded characters in some feeds that do not report  a correct charset in their Content-Type header.

Rome was guessing the charset and decoding wrongly for certain sources 
(e.g. feeds containing Chinese characters).

The fix is to force UTF-8 in XmlReader, which resolves the issue across feeds.

Tested with multiple feeds, including the problematic one.

### Before / After

| Before | After |
|--------|--------|
| <img width="540" height="1170" alt="Screenshot_1763562266" src="https://github.com/user-attachments/assets/5c1fa3bc-b099-447f-a421-f3c87c49cff1" /> | <img width="540" height="1170" alt="Screenshot_1763561008" src="https://github.com/user-attachments/assets/b8d5804d-053a-41da-b3a9-7acd6a2796e3" /> |

