### PR TITLE
fix(ui): improve starred icon visibility in articles list

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -44,6 +45,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -289,11 +291,16 @@ fun ArticleItem(
 
 @Composable
 fun StarredIcon(modifier: Modifier = Modifier) {
+    val fontSize = LocalTextStyle.current.fontSize
+    val iconSize = with(LocalDensity.current) { fontSize.toDp() }
+
     Icon(
-        modifier = modifier.size(14.dp).padding(end = 2.dp),
+        modifier = modifier
+            .size(iconSize)
+            .padding(end = 2.dp),
         imageVector = Icons.Rounded.Star,
         contentDescription = stringResource(R.string.starred),
-        tint = MaterialTheme.colorScheme.outlineVariant,
+        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
     )
 }
 


### PR DESCRIPTION
Fixes: #1192 

This PR improves the visibility of the "starred icon" in the article list.

### What this PR changes
- The icon now scales dynamically based on the current text size, so it respects user font scaling.
- Color is updated to a higher-contrast `onSurface` with slight alpha.


| Before | After |
|--------|--------|
| <img width="480" height="960" alt="Screenshot_1764093141" src="https://github.com/user-attachments/assets/f44b22bb-2660-4496-854d-2080c96ae776" /> | <img width="480" height="960" alt="Screenshot_1764095334" src="https://github.com/user-attachments/assets/c83a26d5-d289-4da3-b719-284143344823" /> |

###  Code changes:

```diff
@Composable
fun StarredIcon(modifier: Modifier = Modifier) {
+    val fontSize = LocalTextStyle.current.fontSize
+    val iconSize = with(LocalDensity.current) { fontSize.toDp() }

    Icon(
        modifier = modifier
-            .size(16.dp)
+            .size(iconSize) //  scales with font size
            .padding(end = 2.dp),
        imageVector = Icons.Rounded.Star,
        contentDescription = stringResource(R.string.starred),
-        tint = Color.Gray,
+        tint = MaterialTheme.colorScheme
+            .onSurface
+            .copy(alpha = 0.7f), //  better visibility (theme-adaptive)
    )
}



