### PR TITLE
fix: Handle invalid dates (e.g., Jalali calendar) by adding validation and fallback to updated date

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/RssHelper.kt
@@ -25,6 +25,7 @@ import me.ash.reader.ui.ext.currentAccountId
 import me.ash.reader.ui.ext.decodeHTML
 import me.ash.reader.ui.ext.extractDomain
 import me.ash.reader.ui.ext.isFuture
+import me.ash.reader.ui.ext.isTooOld
 import me.ash.reader.ui.ext.spacerDollar
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -176,7 +177,8 @@ constructor(
             accountId = accountId,
             feedId = feed.id,
             date =
-                (syndEntry.publishedDate ?: syndEntry.updatedDate)?.takeIf { !it.isFuture(preDate) }
+                syndEntry.publishedDate?.takeIf { !it.isFuture(preDate) && !it.isTooOld() }
+                    ?: syndEntry.updatedDate?.takeIf { !it.isFuture(preDate) && !it.isTooOld() }
                     ?: preDate,
             title = syndEntry.title.decodeHTML() ?: feed.name,
             author = syndEntry.author,

--- a/app/src/main/java/me/ash/reader/ui/ext/DateExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/DateExt.kt
@@ -88,3 +88,8 @@ private fun String.parseToDate(
 }
 
 fun Date.isFuture(staticDate: Date = Date()): Boolean = this.time > staticDate.time
+
+fun Date.isTooOld(minYear: Int = 1970): Boolean {
+    val cal = Calendar.getInstance().apply { time = this@isTooOld }
+    return cal.get(Calendar.YEAR) < minYear
+}


### PR DESCRIPTION
## Summary
- Add date validation to reject dates with unreasonable years (before 1970)
- Fall back to `updatedDate` when `publishedDate` is invalid
- Fixes incorrect date display for feeds using non-Gregorian calendars (e.g., Persian/Jalali)

## Problem
Some RSS/Atom feeds use Jalali (Persian) calendar dates with Persian numerals in the `<published>` tag:

```xml
<updated>2026-01-27T17:42:38Z</updated>
<published>۱۴۰۴-۱۱-۰۷T۱۱:۳۲:۰۶Z</published>
```

The Rome library converts Persian numerals (۰-۹) to ASCII (0-9) and parses 1404-11-07 as a valid Gregorian date. This results in articles displaying as "November 7, 1404" instead of the correct date (Jan 24, 2026).

## Solution
Added isTooOld() validation that rejects dates before 1970 (Unix epoch). When publishedDate fails validation, we now fall back to updatedDate before using the current time.

## Steps to Reproduce
1. Add an RSS feed that uses Jalali dates (e.g., https://mrshabanali.com/feed/atom/)
2. Observe that articles show dates like "November 7, 1404"
3. With this fix, articles correctly show the date from <updated> tag

<img width="320" height="714" alt="image" src="https://github.com/user-attachments/assets/96b1c722-104d-40d7-b816-f98adea5ba3e" />
