### PR TITLE
translation feature added

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,6 +178,7 @@ dependencies {
     implementation(libs.browser)
     implementation(libs.navigation.compose)
     implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.lifecycle.runtime.compose)
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)
@@ -199,6 +200,8 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.timber)
+    implementation(libs.mlkit.translate)
+    implementation(libs.mlkit.language.id)
 
     // Testing
     testImplementation(libs.junit)

--- a/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/8.json
+++ b/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/8.json
@@ -1,0 +1,421 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "dd85b23766e2db32a9c3244e32a6f0be",
+    "entities": [
+      {
+        "tableName": "account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `updateAt` INTEGER, `lastArticleId` TEXT, `syncInterval` INTEGER NOT NULL DEFAULT 30, `syncOnStart` INTEGER NOT NULL DEFAULT 0, `syncOnlyOnWiFi` INTEGER NOT NULL DEFAULT 0, `syncOnlyWhenCharging` INTEGER NOT NULL DEFAULT 0, `keepArchived` INTEGER NOT NULL DEFAULT 2592000000, `syncBlockList` TEXT NOT NULL DEFAULT '', `securityKey` TEXT DEFAULT 'CvJ1PKM8EW8=')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateAt",
+            "columnName": "updateAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastArticleId",
+            "columnName": "lastArticleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncInterval",
+            "columnName": "syncInterval",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "30"
+          },
+          {
+            "fieldPath": "syncOnStart",
+            "columnName": "syncOnStart",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "syncOnlyOnWiFi",
+            "columnName": "syncOnlyOnWiFi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "syncOnlyWhenCharging",
+            "columnName": "syncOnlyWhenCharging",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "keepArchived",
+            "columnName": "keepArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "2592000000"
+          },
+          {
+            "fieldPath": "syncBlockList",
+            "columnName": "syncBlockList",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "securityKey",
+            "columnName": "securityKey",
+            "affinity": "TEXT",
+            "defaultValue": "'CvJ1PKM8EW8='"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `url` TEXT NOT NULL, `groupId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `isNotification` INTEGER NOT NULL, `isFullContent` INTEGER NOT NULL, `isBrowser` INTEGER NOT NULL DEFAULT 0, `isTranslate` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`groupId`) REFERENCES `group`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNotification",
+            "columnName": "isNotification",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFullContent",
+            "columnName": "isFullContent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBrowser",
+            "columnName": "isBrowser",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTranslate",
+            "columnName": "isTranslate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_feed_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "article",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` INTEGER NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `rawDescription` TEXT NOT NULL, `shortDescription` TEXT NOT NULL, `fullContent` TEXT, `img` TEXT, `link` TEXT NOT NULL, `feedId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `isUnread` INTEGER NOT NULL, `isStarred` INTEGER NOT NULL, `isReadLater` INTEGER NOT NULL, `updateAt` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`feedId`) REFERENCES `feed`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rawDescription",
+            "columnName": "rawDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortDescription",
+            "columnName": "shortDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullContent",
+            "columnName": "fullContent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "img",
+            "columnName": "img",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnread",
+            "columnName": "isUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "isStarred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isReadLater",
+            "columnName": "isReadLater",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateAt",
+            "columnName": "updateAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_article_feedId",
+            "unique": false,
+            "columnNames": [
+              "feedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_article_feedId` ON `${TABLE_NAME}` (`feedId`)"
+          },
+          {
+            "name": "index_article_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_article_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "feedId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `accountId` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "archived_article",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feedId` TEXT NOT NULL, `link` TEXT NOT NULL, FOREIGN KEY(`feedId`) REFERENCES `feed`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "feed",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "feedId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dd85b23766e2db32a9c3244e32a6f0be')"
+    ]
+  }
+}

--- a/app/src/main/java/me/ash/reader/domain/model/feed/Feed.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/feed/Feed.kt
@@ -35,6 +35,8 @@ data class Feed(
     val isFullContent: Boolean = false,
     @ColumnInfo(defaultValue = "0")
     val isBrowser: Boolean = false,
+    @ColumnInfo(defaultValue = "0")
+    val isTranslate: Boolean = false,
     @Ignore val important: Int = 0
 ) {
     constructor(
@@ -46,7 +48,8 @@ data class Feed(
         accountId: Int,
         isNotification: Boolean,
         isFullContent: Boolean,
-        isBrowser: Boolean
+        isBrowser: Boolean,
+        isTranslate: Boolean
     ) : this(
         id = id,
         name = name,
@@ -57,6 +60,7 @@ data class Feed(
         isNotification = isNotification,
         isFullContent = isFullContent,
         isBrowser = isBrowser,
+        isTranslate = isTranslate,
         important = 0
     )
 }

--- a/app/src/main/java/me/ash/reader/domain/repository/FeedDao.kt
+++ b/app/src/main/java/me/ash/reader/domain/repository/FeedDao.kt
@@ -86,6 +86,19 @@ interface FeedDao {
 
     @Query(
         """
+        UPDATE feed SET isTranslate = :isTranslate
+        WHERE id = :feedId
+        AND accountId = :accountId
+        """
+    )
+    suspend fun updateIsTranslateByFeedId(
+        accountId: Int,
+        feedId: String,
+        isTranslate: Boolean,
+    )
+
+    @Query(
+        """
         SELECT * FROM feed
         WHERE groupId = :groupId
         AND accountId = :accountId
@@ -189,6 +202,7 @@ interface FeedDao {
                         isNotification = existing.isNotification,
                         isFullContent = existing.isFullContent,
                         isBrowser = existing.isBrowser,
+                        isTranslate = existing.isTranslate,
                     )
                 if (updated == existing) {
                     null

--- a/app/src/main/java/me/ash/reader/infrastructure/db/AndroidDatabase.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/db/AndroidDatabase.kt
@@ -20,11 +20,12 @@ import java.util.*
 
 @Database(
     entities = [Account::class, Feed::class, Article::class, Group::class, ArchivedArticle::class],
-    version = 7,
+    version = 8,
     autoMigrations = [
         AutoMigration(from = 5, to = 6),
         AutoMigration(from = 5, to = 7),
         AutoMigration(from = 6, to = 7),
+        AutoMigration(from = 7, to = 8),
     ]
 )
 @TypeConverters(

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/Preference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/Preference.kt
@@ -89,5 +89,12 @@ fun Preferences.toSettings(): Settings {
 
         // Languages
         languages = LanguagesPreference.fromPreferences(this),
+
+        // Translation
+        // Translation
+        translateArticle = TranslateArticlePreference.fromPreferences(this),
+        translateTargetLanguage = TranslateTargetLanguagePreference.fromPreferences(this),
+        translateWifiOnly = TranslateWifiOnlyPreference.fromPreferences(this),
+        translateTitle = TranslateTitlePreference.fromPreferences(this),
     )
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/Settings.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/Settings.kt
@@ -82,5 +82,12 @@ data class Settings(
 
     // Languages
     val languages: LanguagesPreference = LanguagesPreference.default,
+
+    // Translation
+    // Translation
+    val translateArticle: TranslateArticlePreference = TranslateArticlePreference.default,
+    val translateTargetLanguage: TranslateTargetLanguagePreference = TranslateTargetLanguagePreference.default,
+    val translateWifiOnly: TranslateWifiOnlyPreference = TranslateWifiOnlyPreference.default,
+    val translateTitle: TranslateTitlePreference = TranslateTitlePreference.default,
 )
 

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/SettingsProvider.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/SettingsProvider.kt
@@ -140,6 +140,13 @@ class SettingsProvider @Inject constructor(
 
             // Languages
             LocalLanguages provides settings.languages,
+
+            // Translation
+            // Translation
+            LocalTranslateArticle provides settings.translateArticle,
+            LocalTranslateTargetLanguage provides settings.translateTargetLanguage,
+            LocalTranslateWifiOnly provides settings.translateWifiOnly,
+            LocalTranslateTitle provides settings.translateTitle,
         ) {
             content()
         }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/TranslateArticlePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/TranslateArticlePreference.kt
@@ -1,0 +1,44 @@
+package me.ash.reader.infrastructure.preference
+
+import android.content.Context
+import androidx.compose.runtime.compositionLocalOf
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.DataStoreKey.Companion.translateArticle
+import me.ash.reader.ui.ext.dataStore
+import me.ash.reader.ui.ext.put
+
+val LocalTranslateArticle =
+    compositionLocalOf<TranslateArticlePreference> { TranslateArticlePreference.default }
+
+sealed class TranslateArticlePreference(val value: Boolean) : Preference() {
+    object ON : TranslateArticlePreference(true)
+    object OFF : TranslateArticlePreference(false)
+
+    override fun put(context: Context, scope: CoroutineScope) {
+        scope.launch {
+            context.dataStore.put(translateArticle, value)
+        }
+    }
+
+    companion object {
+
+        val default = OFF
+        val values = listOf(ON, OFF)
+
+        fun fromPreferences(preferences: Preferences) =
+            when (preferences[DataStoreKey.keys[translateArticle]?.key as Preferences.Key<Boolean>]) {
+                true -> ON
+                false -> OFF
+                else -> default
+            }
+    }
+}
+
+operator fun TranslateArticlePreference.not(): TranslateArticlePreference =
+    when (value) {
+        true -> TranslateArticlePreference.OFF
+        false -> TranslateArticlePreference.ON
+    }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/TranslateTargetLanguagePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/TranslateTargetLanguagePreference.kt
@@ -1,0 +1,226 @@
+package me.ash.reader.infrastructure.preference
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.res.stringResource
+import androidx.core.os.LocaleListCompat
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import me.ash.reader.R
+import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.DataStoreKey.Companion.translateTargetLanguage
+import me.ash.reader.ui.ext.dataStore
+import me.ash.reader.ui.ext.put
+import java.util.Locale
+
+val LocalTranslateTargetLanguage = compositionLocalOf<TranslateTargetLanguagePreference> { TranslateTargetLanguagePreference.default }
+
+sealed class TranslateTargetLanguagePreference(val value: Int) : Preference() {
+    data object UseDeviceLanguages : TranslateTargetLanguagePreference(0)
+    data object English : TranslateTargetLanguagePreference(1)
+    data object ChineseSimplified : TranslateTargetLanguagePreference(2)
+    data object German : TranslateTargetLanguagePreference(3)
+    data object French : TranslateTargetLanguagePreference(4)
+    data object Czech : TranslateTargetLanguagePreference(5)
+    data object Italian : TranslateTargetLanguagePreference(6)
+    data object Hindi : TranslateTargetLanguagePreference(7)
+    data object Spanish : TranslateTargetLanguagePreference(8)
+    data object Polish : TranslateTargetLanguagePreference(9)
+    data object Russian : TranslateTargetLanguagePreference(10)
+    data object Basque : TranslateTargetLanguagePreference(11)
+    data object Indonesian : TranslateTargetLanguagePreference(12)
+    data object ChineseTraditional : TranslateTargetLanguagePreference(13)
+    data object Arabic : TranslateTargetLanguagePreference(14)
+    data object Bulgarian : TranslateTargetLanguagePreference(15)
+    data object Catalan : TranslateTargetLanguagePreference(16)
+    data object Danish : TranslateTargetLanguagePreference(17)
+    data object Dutch : TranslateTargetLanguagePreference(18)
+    data object Esperanto : TranslateTargetLanguagePreference(19)
+    data object Filipino : TranslateTargetLanguagePreference(20)
+    data object Hebrew : TranslateTargetLanguagePreference(21)
+    data object Hungarian : TranslateTargetLanguagePreference(22)
+    data object Japanese : TranslateTargetLanguagePreference(23)
+    data object Kannada : TranslateTargetLanguagePreference(24)
+    data object NorwegianBokmal : TranslateTargetLanguagePreference(25)
+    data object Persian : TranslateTargetLanguagePreference(26)
+    data object Portuguese : TranslateTargetLanguagePreference(27)
+    data object PortugueseBrazil : TranslateTargetLanguagePreference(28)
+    data object Romanian : TranslateTargetLanguagePreference(29)
+    data object Serbian : TranslateTargetLanguagePreference(30)
+    data object Slovenian : TranslateTargetLanguagePreference(31)
+    data object Swedish : TranslateTargetLanguagePreference(32)
+    data object Turkish : TranslateTargetLanguagePreference(33)
+    data object Ukrainian : TranslateTargetLanguagePreference(34)
+    data object Vietnamese : TranslateTargetLanguagePreference(35)
+    data object ArabicNorthLevantine : TranslateTargetLanguagePreference(36)
+    data object Estonian : TranslateTargetLanguagePreference(37)
+    data object Galician : TranslateTargetLanguagePreference(38)
+    data object Slovak : TranslateTargetLanguagePreference(39)
+    data object Tamil : TranslateTargetLanguagePreference(40)
+
+
+    override fun put(context: Context, scope: CoroutineScope) {
+        scope.launch {
+            context.dataStore.put(
+                DataStoreKey.translateTargetLanguage, value
+            )
+        }
+    }
+
+    @Composable
+    fun toDesc(): String {
+        return when (this) {
+            ChineseTraditional -> stringResource(id = R.string.chinese_traditional)
+            ChineseSimplified -> stringResource(id = R.string.chinese_simplified)
+            else -> {
+                this.toLocale().toDisplayName()
+            }
+        }
+    }
+
+
+    fun toLocale(): Locale? = when (this) {
+        UseDeviceLanguages -> null
+        English -> Locale("en")
+        ChineseSimplified -> Locale.forLanguageTag("zh-Hans")
+        German -> Locale("de")
+        French -> Locale("fr")
+        Czech -> Locale("cs")
+        Italian -> Locale("it")
+        Hindi -> Locale("hi")
+        Spanish -> Locale("es")
+        Polish -> Locale("pl")
+        Russian -> Locale("ru")
+        Basque -> Locale("eu")
+        Indonesian -> Locale("in")
+        ChineseTraditional -> Locale.forLanguageTag("zh-Hant")
+        Arabic -> Locale("ar")
+        Bulgarian -> Locale("bg")
+        Catalan -> Locale("ca")
+        Danish -> Locale("da")
+        Dutch -> Locale("nl")
+        Esperanto -> Locale("eo")
+        Filipino -> Locale("fil")
+        Hebrew -> Locale("he")
+        Hungarian -> Locale("hu")
+        Japanese -> Locale("ja")
+        Kannada -> Locale("kn")
+        NorwegianBokmal -> Locale("nb")
+        Persian -> Locale("fa")
+        Portuguese -> Locale("pt")
+        PortugueseBrazil -> Locale("pt", "BR")
+        Romanian -> Locale("ro")
+        Serbian -> Locale("sr")
+        Slovenian -> Locale("sl")
+        Swedish -> Locale("sv")
+        Turkish -> Locale("tr")
+        Ukrainian -> Locale("uk")
+        Vietnamese -> Locale("vi")
+        ArabicNorthLevantine -> Locale.forLanguageTag("apc")
+        Estonian -> Locale("et")
+        Galician -> Locale("gl")
+        Slovak -> Locale("sk")
+        Tamil -> Locale("ta")
+    }
+
+    companion object {
+
+        val default = UseDeviceLanguages
+
+        val values = listOf(
+            UseDeviceLanguages,
+            Arabic,
+            ArabicNorthLevantine,
+            Basque,
+            Bulgarian,
+            Catalan,
+            ChineseSimplified,
+            ChineseTraditional,
+            Czech,
+            Danish,
+            Dutch,
+            English,
+            Esperanto,
+            Estonian,
+            Filipino,
+            French,
+            Galician,
+            German,
+            Hebrew,
+            Hindi,
+            Hungarian,
+            Indonesian,
+            Italian,
+            Japanese,
+            Kannada,
+            NorwegianBokmal,
+            Persian,
+            Polish,
+            Portuguese,
+            PortugueseBrazil,
+            Romanian,
+            Russian,
+            Serbian,
+            Slovak,
+            Slovenian,
+            Spanish,
+            Swedish,
+            Tamil,
+            Turkish,
+            Ukrainian,
+            Vietnamese
+        )
+
+        fun fromPreferences(preferences: Preferences): TranslateTargetLanguagePreference =
+            fromValue(preferences[DataStoreKey.keys[translateTargetLanguage]?.key as Preferences.Key<Int>] ?: 0)
+
+
+        fun fromValue(value: Int): TranslateTargetLanguagePreference = when (value) {
+            0 -> UseDeviceLanguages
+            1 -> English
+            2 -> ChineseSimplified
+            3 -> German
+            4 -> French
+            5 -> Czech
+            6 -> Italian
+            7 -> Hindi
+            8 -> Spanish
+            9 -> Polish
+            10 -> Russian
+            11 -> Basque
+            12 -> Indonesian
+            13 -> ChineseTraditional
+            14 -> Arabic
+            15 -> Bulgarian
+            16 -> Catalan
+            17 -> Danish
+            18 -> Dutch
+            19 -> Esperanto
+            20 -> Filipino
+            21 -> Hebrew
+            22 -> Hungarian
+            23 -> Japanese
+            24 -> Kannada
+            25 -> NorwegianBokmal
+            26 -> Persian
+            27 -> Portuguese
+            28 -> PortugueseBrazil
+            29 -> Romanian
+            30 -> Serbian
+            31 -> Slovenian
+            32 -> Swedish
+            33 -> Turkish
+            34 -> Ukrainian
+            35 -> Vietnamese
+            36 -> ArabicNorthLevantine
+            37 -> Estonian
+            38 -> Galician
+            39 -> Slovak
+            40 -> Tamil
+            else -> default
+        }
+
+    }
+}

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/TranslateTitlePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/TranslateTitlePreference.kt
@@ -1,0 +1,44 @@
+package me.ash.reader.infrastructure.preference
+
+import android.content.Context
+import androidx.compose.runtime.compositionLocalOf
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.DataStoreKey.Companion.translateTitle
+import me.ash.reader.ui.ext.dataStore
+import me.ash.reader.ui.ext.put
+
+val LocalTranslateTitle =
+    compositionLocalOf<TranslateTitlePreference> { TranslateTitlePreference.default }
+
+sealed class TranslateTitlePreference(val value: Boolean) : Preference() {
+    object ON : TranslateTitlePreference(true)
+    object OFF : TranslateTitlePreference(false)
+
+    override fun put(context: Context, scope: CoroutineScope) {
+        scope.launch {
+            context.dataStore.put(translateTitle, value)
+        }
+    }
+
+    companion object {
+
+        val default = ON
+        val values = listOf(ON, OFF)
+
+        fun fromPreferences(preferences: Preferences) =
+            when (preferences[DataStoreKey.keys[translateTitle]?.key as Preferences.Key<Boolean>]) {
+                true -> ON
+                false -> OFF
+                else -> default
+            }
+    }
+}
+
+operator fun TranslateTitlePreference.not(): TranslateTitlePreference =
+    when (value) {
+        true -> TranslateTitlePreference.OFF
+        false -> TranslateTitlePreference.ON
+    }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/TranslateWifiOnlyPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/TranslateWifiOnlyPreference.kt
@@ -1,0 +1,44 @@
+package me.ash.reader.infrastructure.preference
+
+import android.content.Context
+import androidx.compose.runtime.compositionLocalOf
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.DataStoreKey.Companion.translateWifiOnly
+import me.ash.reader.ui.ext.dataStore
+import me.ash.reader.ui.ext.put
+
+val LocalTranslateWifiOnly =
+    compositionLocalOf<TranslateWifiOnlyPreference> { TranslateWifiOnlyPreference.default }
+
+sealed class TranslateWifiOnlyPreference(val value: Boolean) : Preference() {
+    data object ON : TranslateWifiOnlyPreference(true)
+    data object OFF : TranslateWifiOnlyPreference(false)
+
+    override fun put(context: Context, scope: CoroutineScope) {
+        scope.launch {
+            context.dataStore.put(translateWifiOnly, value)
+        }
+    }
+
+    companion object {
+
+        val default = ON
+        val values = listOf(ON, OFF)
+
+        fun fromPreferences(preferences: Preferences) =
+            when (preferences[DataStoreKey.keys[translateWifiOnly]?.key as Preferences.Key<Boolean>]) {
+                true -> ON
+                false -> OFF
+                else -> default
+            }
+    }
+}
+
+operator fun TranslateWifiOnlyPreference.not(): TranslateWifiOnlyPreference =
+    when (value) {
+        true -> TranslateWifiOnlyPreference.OFF
+        false -> TranslateWifiOnlyPreference.ON
+    }

--- a/app/src/main/java/me/ash/reader/infrastructure/translation/TranslationService.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/translation/TranslationService.kt
@@ -1,0 +1,391 @@
+package me.ash.reader.infrastructure.translation
+
+import android.content.Context
+import android.util.LruCache
+import com.google.mlkit.common.model.DownloadConditions
+import com.google.mlkit.common.model.RemoteModelManager
+import com.google.mlkit.nl.languageid.LanguageIdentification
+import com.google.mlkit.nl.translate.TranslateLanguage
+import com.google.mlkit.nl.translate.TranslateRemoteModel
+import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.Translator
+import com.google.mlkit.nl.translate.TranslatorOptions
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import me.ash.reader.infrastructure.di.IODispatcher
+import me.ash.reader.infrastructure.preference.SettingsProvider
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.TextNode
+import timber.log.Timber
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+private const val LANGUAGE_ID_SAMPLE_LENGTH = 500
+private const val BATCH_SEPARATOR = "\n\uFFFF\n"
+private const val TRANSLATION_CACHE_SIZE = 30
+private const val CHUNK_SIZE = 50
+
+@Singleton
+class TranslationService @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val settingsProvider: SettingsProvider,
+) {
+
+    private val modelManager = RemoteModelManager.getInstance()
+    private val languageIdentifier = LanguageIdentification.getClient()
+    private val translatorCache = mutableMapOf<String, Translator>()
+
+    /** Cache of translated content keyed by "articleId_targetLanguage". */
+    private val translationCache = LruCache<String, String>(TRANSLATION_CACHE_SIZE)
+
+    /**
+     * Get the target language tag based on the current app language setting.
+     * Falls back to device locale if "Use Device Languages" is selected.
+     */
+    fun getTargetLanguageTag(): String {
+        val targetPref = settingsProvider.settings.translateTargetLanguage
+        if (targetPref.value != 0) {
+            return targetPref.toLocale()?.let {
+                TranslateLanguage.fromLanguageTag(it.toLanguageTag())
+            } ?: TranslateLanguage.ENGLISH
+        }
+
+        val languagePref = settingsProvider.settings.languages
+        val locale = languagePref.toLocale() ?: Locale.getDefault()
+        return TranslateLanguage.fromLanguageTag(locale.toLanguageTag())
+            ?: TranslateLanguage.fromLanguageTag(locale.language)
+            ?: TranslateLanguage.ENGLISH
+    }
+
+    /**
+     * Identify the language of HTML content by stripping tags and decoding entities first.
+     * This is the preferred method when working with article HTML content,
+     * because raw HTML entities (e.g. &#xFC;) confuse ML Kit's language identifier.
+     */
+    suspend fun identifyHtmlLanguage(html: String): String {
+        if (html.isBlank()) return "und"
+        val plainText = Jsoup.parse(html).text()
+        return identifyLanguage(plainText)
+    }
+
+    /**
+     * Identify the source language of a text using ML Kit.
+     * Uses only the first [LANGUAGE_ID_SAMPLE_LENGTH] chars for speed.
+     * Returns "und" if undetermined.
+     */
+    suspend fun identifyLanguage(text: String): String = suspendCancellableCoroutine { cont ->
+        if (text.isBlank()) {
+            cont.resume("und")
+            return@suspendCancellableCoroutine
+        }
+        val sample = text.take(LANGUAGE_ID_SAMPLE_LENGTH)
+        languageIdentifier.identifyLanguage(sample)
+            .addOnSuccessListener { languageCode ->
+                cont.resume(languageCode)
+            }
+            .addOnFailureListener {
+                cont.resume("und")
+            }
+    }
+
+    /**
+     * Check whether the required translation models (source & target) are already downloaded.
+     * Returns true only if both models are available locally.
+     */
+    suspend fun areModelsDownloaded(sourceLanguage: String, targetLanguage: String): Boolean =
+        withContext(ioDispatcher) {
+            coroutineScope {
+                val sourceDownloaded = async { isModelDownloaded(sourceLanguage) }
+                val targetDownloaded = async { isModelDownloaded(targetLanguage) }
+                sourceDownloaded.await() && targetDownloaded.await()
+            }
+        }
+
+    /**
+     * Get a cached translation result, or null if not cached.
+     */
+    fun getCachedTranslation(articleId: String, targetLanguage: String): String? {
+        return translationCache.get("${articleId}_$targetLanguage")
+    }
+
+    /**
+     * Translate HTML content, preserving HTML structure.
+     * Only text nodes are translated; tags and attributes are kept intact.
+     * Uses batch translation for efficiency.
+     */
+    suspend fun translateHtml(
+        htmlContent: String,
+        targetLanguage: String = getTargetLanguageTag(),
+        articleId: String? = null,
+        onProgress: (Float) -> Unit = {},
+    ): Result<String> = withContext(ioDispatcher) {
+        // Check cache first
+        if (articleId != null) {
+            val cached = getCachedTranslation(articleId, targetLanguage)
+            if (cached != null) {
+                Timber.d("Translation cache hit for article=$articleId, lang=$targetLanguage")
+                return@withContext Result.success(cached)
+            }
+        }
+        runCatching {
+            val document = Jsoup.parseBodyFragment(htmlContent)
+            val bodyText = document.body().text()
+            val sourceLanguage = identifyLanguage(bodyText)
+            if (sourceLanguage == "und" || sourceLanguage == targetLanguage) {
+                return@withContext Result.success(htmlContent)
+            }
+
+            translateElement(document.body(), sourceLanguage, targetLanguage, onProgress)
+            val result = document.body().html()
+
+            // Store in cache
+            if (articleId != null) {
+                translationCache.put("${articleId}_$targetLanguage", result)
+            }
+            result
+        }
+    }
+
+    /**
+     * Translate plain text.
+     */
+    suspend fun translateText(
+        text: String,
+        targetLanguage: String = getTargetLanguageTag(),
+    ): Result<String> = withContext(ioDispatcher) {
+        if (text.isBlank()) return@withContext Result.success(text)
+        runCatching {
+            val sourceLanguage = identifyLanguage(text)
+            if (sourceLanguage == "und" || sourceLanguage == targetLanguage) {
+                return@withContext Result.success(text)
+            }
+
+            val translator = getOrCreateTranslator(sourceLanguage, targetLanguage)
+            ensureModelDownloaded(translator)
+            suspendCancellableCoroutine { cont ->
+                translator.translate(text)
+                    .addOnSuccessListener { cont.resume(it) }
+                    .addOnFailureListener { cont.resume(text) }
+            }
+        }
+    }
+
+    /**
+     * Translate plain text with an explicit source language (skips language detection).
+     */
+    suspend fun translateText(
+        text: String,
+        sourceLanguage: String,
+        targetLanguage: String,
+    ): Result<String> = withContext(ioDispatcher) {
+        if (text.isBlank()) return@withContext Result.success(text)
+        runCatching {
+            val translator = getOrCreateTranslator(sourceLanguage, targetLanguage)
+            ensureModelDownloaded(translator)
+            suspendCancellableCoroutine { cont ->
+                translator.translate(text)
+                    .addOnSuccessListener { cont.resume(it) }
+                    .addOnFailureListener { cont.resume(text) }
+            }
+        }
+    }
+
+    /**
+     * Download a language model for offline use.
+     */
+    suspend fun downloadModel(languageTag: String): Result<Unit> = withContext(ioDispatcher) {
+        runCatching {
+            val options = TranslatorOptions.Builder()
+                .setSourceLanguage(languageTag)
+                .setTargetLanguage(TranslateLanguage.ENGLISH)
+                .build()
+            val translator = Translation.getClient(options)
+            val conditions = DownloadConditions.Builder()
+                .requireWifi()
+                .build()
+            suspendCancellableCoroutine { cont ->
+                translator.downloadModelIfNeeded(conditions)
+                    .addOnSuccessListener { cont.resume(Unit) }
+                    .addOnFailureListener { throw it }
+            }
+            translator.close()
+        }
+    }
+
+    /**
+     * Check if a language model has been downloaded.
+     */
+    suspend fun isModelDownloaded(languageTag: String): Boolean = withContext(ioDispatcher) {
+        suspendCancellableCoroutine { cont ->
+            val model = TranslateRemoteModel.Builder(languageTag).build()
+            modelManager.isModelDownloaded(model)
+                .addOnSuccessListener { cont.resume(it) }
+                .addOnFailureListener { cont.resume(false) }
+        }
+    }
+
+    /**
+     * Delete a downloaded language model.
+     */
+    suspend fun deleteModel(languageTag: String): Result<Unit> = withContext(ioDispatcher) {
+        runCatching {
+            val model = TranslateRemoteModel.Builder(languageTag).build()
+            suspendCancellableCoroutine { cont ->
+                modelManager.deleteDownloadedModel(model)
+                    .addOnSuccessListener { cont.resume(Unit) }
+                    .addOnFailureListener { throw it }
+            }
+        }
+    }
+
+    /**
+     * Get a list of downloaded language models.
+     */
+    suspend fun getDownloadedModels(): List<String> = withContext(ioDispatcher) {
+        suspendCancellableCoroutine { cont ->
+            modelManager.getDownloadedModels(TranslateRemoteModel::class.java)
+                .addOnSuccessListener { models ->
+                    cont.resume(models.map { it.language })
+                }
+                .addOnFailureListener { cont.resume(emptyList()) }
+        }
+    }
+
+    /**
+     * Download models and then translate. Called after user confirms the download.
+     */
+    suspend fun downloadAndTranslateHtml(
+        htmlContent: String,
+        sourceLanguage: String,
+        targetLanguage: String,
+        articleId: String? = null,
+        onProgress: (Float) -> Unit = {},
+    ): Result<String> = withContext(ioDispatcher) {
+        runCatching {
+            val translator = getOrCreateTranslator(sourceLanguage, targetLanguage)
+            ensureModelDownloaded(translator)
+
+            val document = Jsoup.parseBodyFragment(htmlContent)
+            translateElement(document.body(), sourceLanguage, targetLanguage, onProgress)
+            val result = document.body().html()
+
+            if (articleId != null) {
+                translationCache.put("${articleId}_$targetLanguage", result)
+            }
+            result
+        }
+    }
+
+    private fun getOrCreateTranslator(sourceLanguage: String, targetLanguage: String): Translator {
+        val key = "${sourceLanguage}_$targetLanguage"
+        return translatorCache.getOrPut(key) {
+            val options = TranslatorOptions.Builder()
+                .setSourceLanguage(sourceLanguage)
+                .setTargetLanguage(targetLanguage)
+                .build()
+            Translation.getClient(options)
+        }
+    }
+
+    private suspend fun ensureModelDownloaded(translator: Translator) {
+        val wifiOnly = settingsProvider.settings.translateWifiOnly.value
+        val conditions = if (wifiOnly) {
+            DownloadConditions.Builder().requireWifi().build()
+        } else {
+            DownloadConditions.Builder().build()
+        }
+        suspendCancellableCoroutine { cont ->
+            translator.downloadModelIfNeeded(conditions)
+                .addOnSuccessListener { cont.resume(Unit) }
+                .addOnFailureListener { throw it }
+        }
+    }
+
+    /**
+     * Translate all text nodes in an element using chunked batch translation.
+     * Splits text nodes into groups of [CHUNK_SIZE], translates each chunk as a batch,
+     * and reports progress after each chunk. DOM is modified in-place; the caller
+     * extracts the final HTML only after this method completes (no flickering).
+     */
+    private suspend fun translateElement(
+        element: Element,
+        sourceLanguage: String,
+        targetLanguage: String,
+        onProgress: (Float) -> Unit = {},
+    ) {
+        val textNodes = mutableListOf<TextNode>()
+        collectTextNodes(element, textNodes)
+
+        if (textNodes.isEmpty()) return
+
+        val translator = getOrCreateTranslator(sourceLanguage, targetLanguage)
+        ensureModelDownloaded(translator)
+
+        val nonBlankNodes = textNodes.filter { it.wholeText.isNotBlank() }
+        if (nonBlankNodes.isEmpty()) return
+
+        // Split nodes into chunks for progress reporting
+        val chunks = nonBlankNodes.chunked(CHUNK_SIZE)
+        val totalChunks = chunks.size
+
+        chunks.forEachIndexed { chunkIndex, chunk ->
+            translateChunk(chunk, translator)
+            onProgress((chunkIndex + 1).toFloat() / totalChunks)
+        }
+    }
+
+    /**
+     * Translate a single chunk of text nodes using batch concatenation.
+     * Falls back to one-by-one if the separator is corrupted during translation.
+     */
+    private suspend fun translateChunk(nodes: List<TextNode>, translator: Translator) {
+        val batchText = nodes.joinToString(BATCH_SEPARATOR) { it.wholeText }
+        val translatedBatch = suspendCancellableCoroutine { cont ->
+            translator.translate(batchText)
+                .addOnSuccessListener { cont.resume(it) }
+                .addOnFailureListener { cont.resume(batchText) }
+        }
+
+        val translatedParts = translatedBatch.split(BATCH_SEPARATOR)
+
+        if (translatedParts.size == nodes.size) {
+            nodes.forEachIndexed { index, node ->
+                node.text(translatedParts[index])
+            }
+        } else {
+            // Fallback: translate one-by-one if batch separator was corrupted
+            Timber.w("Batch split mismatch: expected ${nodes.size}, got ${translatedParts.size}. Falling back.")
+            for (node in nodes) {
+                val translated = suspendCancellableCoroutine { cont ->
+                    translator.translate(node.wholeText)
+                        .addOnSuccessListener { cont.resume(it) }
+                        .addOnFailureListener { cont.resume(node.wholeText) }
+                }
+                node.text(translated)
+            }
+        }
+    }
+
+    private fun collectTextNodes(element: Element, result: MutableList<TextNode>) {
+        for (child in element.childNodes()) {
+            when (child) {
+                is TextNode -> if (child.wholeText.isNotBlank()) result.add(child)
+                is Element -> collectTextNodes(child, result)
+            }
+        }
+    }
+
+    fun close() {
+        translatorCache.values.forEach { it.close() }
+        translatorCache.clear()
+        languageIdentifier.close()
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -1,6 +1,5 @@
 package me.ash.reader.ui.component.webview
 
-import android.util.Log
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -100,42 +99,44 @@ fun RYWebView(
         factory = { webView },
         update = {
             it.apply {
-                Log.i("RLog", "maxWidth: ${maxWidth}")
-                Log.i("RLog", "readingFont: ${context.filesDir.absolutePath}")
-                Log.i("RLog", "CustomWebView: ${content}")
-                settings.defaultFontSize = fontSize
-                loadDataWithBaseURL(
-                    null,
-                    WebViewHtml.HTML.format(
-                        WebViewStyle.get(
-                            fontSize = fontSize,
-                            fontPath = fontPath,
-                            lineHeight = lineHeight,
-                            letterSpacing = letterSpacing,
-                            textMargin = textMargin,
-                            textColor = textColor,
-                            textBold = textBold,
-                            textAlign = textAlign,
-                            boldTextColor = boldTextColor,
-                            subheadBold = subheadBold,
-                            subheadUpperCase = subheadUpperCase,
-                            imgMargin = imgMargin,
-                            imgBorderRadius = imgBorderRadius,
-                            linkTextColor = linkTextColor,
-                            codeTextColor = codeTextColor,
-                            codeBgColor = codeBgColor,
-                            tableMargin = textMargin,
-                            selectionTextColor = selectionTextColor,
-                            selectionBgColor = selectionBgColor,
-                        ),
-                        url,
-                        content,
-                        WebViewScript.get(boldCharacters.value),
+                val newHtml = WebViewHtml.HTML.format(
+                    WebViewStyle.get(
+                        fontSize = fontSize,
+                        fontPath = fontPath,
+                        lineHeight = lineHeight,
+                        letterSpacing = letterSpacing,
+                        textMargin = textMargin,
+                        textColor = textColor,
+                        textBold = textBold,
+                        textAlign = textAlign,
+                        boldTextColor = boldTextColor,
+                        subheadBold = subheadBold,
+                        subheadUpperCase = subheadUpperCase,
+                        imgMargin = imgMargin,
+                        imgBorderRadius = imgBorderRadius,
+                        linkTextColor = linkTextColor,
+                        codeTextColor = codeTextColor,
+                        codeBgColor = codeBgColor,
+                        tableMargin = textMargin,
+                        selectionTextColor = selectionTextColor,
+                        selectionBgColor = selectionBgColor,
                     ),
-                    "text/HTML",
-                    "UTF-8",
-                    null,
+                    url,
+                    content,
+                    WebViewScript.get(boldCharacters.value),
                 )
+                // Only reload if content/style actually changed
+                if (tag != newHtml) {
+                    settings.defaultFontSize = fontSize
+                    loadDataWithBaseURL(
+                        null,
+                        newHtml,
+                        "text/HTML",
+                        "UTF-8",
+                        null,
+                    )
+                    tag = newHtml
+                }
             }
         },
     )

--- a/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
@@ -201,6 +201,13 @@ sealed interface PreferencesKey {
         // Languages
         const val languages = "languages"
 
+        // Translation
+        // Translation
+        const val translateArticle = "translateArticle"
+        const val translateTargetLanguage = "translateTargetLanguage"
+        const val translateWifiOnly = "translateWifiOnly"
+        const val translateTitle = "translateTitle"
+
         private val keyList =
             listOf(
                 // Version
@@ -275,6 +282,12 @@ sealed interface PreferencesKey {
                 IntKey(sharedContent),
                 // Languages
                 IntKey(languages),
+                // Translation
+                // Translation
+                BooleanKey(translateArticle),
+                IntKey(translateTargetLanguage),
+                BooleanKey(translateWifiOnly),
+                BooleanKey(translateTitle),
             )
 
         val keys = keyList.associateBy { it.name }
@@ -362,6 +375,13 @@ data class DataStoreKey<T>(val key: Preferences.Key<T>, val type: Class<T>) {
 
         // Languages
         const val languages = "languages"
+
+        // Translation
+        // Translation
+        const val translateArticle = "translateArticle"
+        const val translateTargetLanguage = "translateTargetLanguage"
+        const val translateWifiOnly = "translateWifiOnly"
+        const val translateTitle = "translateTitle"
 
         val keys: MutableMap<String, DataStoreKey<*>> =
             mutableMapOf(
@@ -513,6 +533,16 @@ data class DataStoreKey<T>(val key: Preferences.Key<T>, val type: Class<T>) {
                 sharedContent to DataStoreKey(intPreferencesKey(sharedContent), Int::class.java),
                 // Languages
                 languages to DataStoreKey(intPreferencesKey(languages), Int::class.java),
+                // Translation
+                // Translation
+                translateArticle to
+                    DataStoreKey(booleanPreferencesKey(translateArticle), Boolean::class.java),
+                translateTargetLanguage to
+                    DataStoreKey(intPreferencesKey(translateTargetLanguage), Int::class.java),
+                translateWifiOnly to
+                    DataStoreKey(booleanPreferencesKey(translateWifiOnly), Boolean::class.java),
+                translateTitle to
+                    DataStoreKey(booleanPreferencesKey(translateTitle), Boolean::class.java),
             )
     }
 }

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -46,6 +46,7 @@ import me.ash.reader.infrastructure.di.IODispatcher
 import me.ash.reader.infrastructure.preference.PullToLoadNextFeedPreference
 import me.ash.reader.infrastructure.preference.SettingsProvider
 import me.ash.reader.infrastructure.rss.ReaderCacheHelper
+import me.ash.reader.infrastructure.translation.TranslationService
 import timber.log.Timber
 
 private const val TAG = "FlowViewModel"
@@ -66,6 +67,7 @@ constructor(
     val textToSpeechManager: TextToSpeechManager,
     private val imageDownloader: AndroidImageDownloader,
     private val articleListUseCase: ArticlePagingListUseCase,
+    val translationService: TranslationService,
     workManager: WorkManager,
 ) : ViewModel() {
 
@@ -308,9 +310,23 @@ constructor(
                             author = article.author,
                             link = article.link,
                             publishedDate = article.date,
+                            isTranslated = false,
+                            isTranslating = false,
+                            originalContent = null,
+                            detectedLanguage = null,
+                            needsDownloadConfirmation = false,
+                            pendingSourceLanguage = null,
+                            isDownloadingModel = false,
+                            translationProgress = 0f,
                         )
                         .prefetchArticleId()
                         .renderContent(this)
+                }
+                // Detect article language in background for same-language guard
+                detectArticleLanguage()
+                // Auto-translate if feed has isTranslate enabled
+                if (feed.isTranslate && settingsProvider.settings.translateArticle.value) {
+                    translateContent()
                 }
             }
         }
@@ -319,6 +335,19 @@ constructor(
     fun clearReadingData() {
         _readingUiState.update { ReadingUiState() }
         _readerState.update { ReaderState() }
+    }
+
+    /**
+     * Detect the language of the current article content in the background.
+     * Updates ReaderState.detectedLanguage so the UI can hide the translate button
+     * when the article is already in the target language.
+     */
+    private fun detectArticleLanguage() {
+        viewModelScope.launch {
+            val content = _readerState.value.content.text ?: return@launch
+            val detected = translationService.identifyHtmlLanguage(content)
+            _readerState.update { it.copy(detectedLanguage = detected) }
+        }
     }
 
     suspend fun ReaderState.renderContent(articleWithFeed: ArticleWithFeed): ReaderState {
@@ -336,15 +365,39 @@ constructor(
         return copy(content = contentState)
     }
 
-    fun renderDescriptionContent() {
+    fun renderDescriptionContent(translateTitle: Boolean = false) {
+        val wasTranslated = _readerState.value.isTranslated
         _readerState.update {
             it.copy(
-                content = ReaderState.Description(content = currentArticle?.rawDescription ?: "")
+                content = ReaderState.Description(content = currentArticle?.rawDescription ?: ""),
+                // Reset translation state — content source changed
+                isTranslated = false,
+                isTranslating = false,
+                originalContent = null,
+                title = it.originalTitle ?: it.title,
+                originalTitle = null,
+                translationProgress = 0f,
             )
+        }
+        // Auto-translate the new content if translation was active
+        if (wasTranslated) {
+            translateContent(translateTitle)
         }
     }
 
-    fun renderFullContent() {
+    fun renderFullContent(translateTitle: Boolean = false) {
+        val wasTranslated = _readerState.value.isTranslated
+        // Reset translation state before loading new content
+        _readerState.update {
+            it.copy(
+                isTranslated = false,
+                isTranslating = false,
+                originalContent = null,
+                title = it.originalTitle ?: it.title,
+                originalTitle = null,
+                translationProgress = 0f,
+            )
+        }
         val fetchJob =
             viewModelScope.launch {
                 readerCacheHelper
@@ -352,6 +405,10 @@ constructor(
                     .onSuccess { content ->
                         _readerState.update {
                             it.copy(content = ReaderState.FullContent(content = content))
+                        }
+                        // Auto-translate after full content is loaded
+                        if (wasTranslated) {
+                            translateContent(translateTitle)
                         }
                     }
                     .onFailure { th ->
@@ -388,6 +445,220 @@ constructor(
 
     private fun setLoading() {
         _readerState.update { it.copy(content = ReaderState.Loading) }
+    }
+
+    fun translateContent(translateTitle: Boolean = true) {
+        val currentContent = _readerState.value.content.text ?: return
+        val articleId = _readerState.value.articleId
+        val targetLang = translationService.getTargetLanguageTag()
+
+        // Check cache first
+        if (articleId != null) {
+            val cached = translationService.getCachedTranslation(articleId, targetLang)
+            if (cached != null) {
+                _readerState.update {
+                    it.copy(
+                        originalContent = if (it.originalContent == null) it.content else it.originalContent,
+                        originalTitle = if (it.originalTitle == null) it.title else it.originalTitle,
+                        content = when (it.content) {
+                            is ReaderState.Description -> ReaderState.Description(cached)
+                            is ReaderState.FullContent -> ReaderState.FullContent(cached)
+                            else -> it.content
+                        },
+                        isTranslated = true,
+                        isTranslating = false,
+                    )
+                }
+                // Translate title from cache path too
+                if (translateTitle && !_readerState.value.originalTitle.isNullOrBlank()) {
+                    viewModelScope.launch {
+                        // Detect language from original content (longer text = reliable detection)
+                        val sourceLanguage = translationService.identifyHtmlLanguage(currentContent)
+                        if (sourceLanguage != "und" && sourceLanguage != targetLang) {
+                            translationService.translateText(
+                                text = _readerState.value.originalTitle!!,
+                                sourceLanguage = sourceLanguage,
+                                targetLanguage = targetLang,
+                            ).onSuccess { translatedTitle ->
+                                _readerState.update { it.copy(title = translatedTitle) }
+                            }
+                        }
+                    }
+                }
+                return
+            }
+        }
+
+        _readerState.update {
+            it.copy(
+                isTranslating = true,
+                originalContent = if (it.originalContent == null) it.content else it.originalContent,
+                originalTitle = if (it.originalTitle == null) it.title else it.originalTitle,
+            )
+        }
+
+        viewModelScope.launch {
+            // Identify source language (strip HTML first to avoid entity confusion)
+            val sourceLanguage = translationService.identifyHtmlLanguage(currentContent)
+            if (sourceLanguage == "und" || sourceLanguage == targetLang) {
+                _readerState.update { it.copy(isTranslating = false) }
+                return@launch
+            }
+
+            // Check if models are already downloaded
+            val modelsReady = translationService.areModelsDownloaded(sourceLanguage, targetLang)
+            if (!modelsReady) {
+                // Ask user for confirmation before downloading
+                _readerState.update {
+                    it.copy(
+                        isTranslating = false,
+                        needsDownloadConfirmation = true,
+                        pendingSourceLanguage = sourceLanguage,
+                    )
+                }
+                return@launch
+            }
+
+            // Models are ready, translate directly
+            translationService.translateHtml(
+                htmlContent = currentContent,
+                targetLanguage = targetLang,
+                articleId = articleId,
+                onProgress = { progress ->
+                    _readerState.update { it.copy(translationProgress = progress) }
+                },
+            )
+                .onSuccess { translated ->
+                    // Translate title if enabled
+                    val translatedTitle = if (translateTitle && !_readerState.value.title.isNullOrBlank()) {
+                        translationService.translateText(
+                            text = _readerState.value.title!!,
+                            sourceLanguage = sourceLanguage,
+                            targetLanguage = targetLang,
+                        ).getOrDefault(_readerState.value.title!!)
+                    } else {
+                        _readerState.value.title
+                    }
+                    _readerState.update {
+                        it.copy(
+                            content = when (it.content) {
+                                is ReaderState.Description -> ReaderState.Description(translated)
+                                is ReaderState.FullContent -> ReaderState.FullContent(translated)
+                                else -> it.content
+                            },
+                            title = translatedTitle,
+                            isTranslated = true,
+                            isTranslating = false,
+                            translationProgress = 0f,
+                        )
+                    }
+                }
+                .onFailure {
+                    _readerState.update { it.copy(isTranslating = false, translationProgress = 0f) }
+                }
+        }
+    }
+
+    /**
+     * Called when user confirms the model download dialog.
+     * Downloads models and then translates.
+     */
+    fun confirmDownloadAndTranslate(translateTitle: Boolean = true) {
+        val currentContent = _readerState.value.content.text ?: return
+        val sourceLanguage = _readerState.value.pendingSourceLanguage ?: return
+        val targetLang = translationService.getTargetLanguageTag()
+        val articleId = _readerState.value.articleId
+
+        _readerState.update {
+            it.copy(
+                needsDownloadConfirmation = false,
+                pendingSourceLanguage = null,
+                isTranslating = true,
+                isDownloadingModel = true,
+            )
+        }
+
+        viewModelScope.launch {
+            translationService.downloadAndTranslateHtml(
+                htmlContent = currentContent,
+                sourceLanguage = sourceLanguage,
+                targetLanguage = targetLang,
+                articleId = articleId,
+                onProgress = { progress ->
+                    _readerState.update { it.copy(translationProgress = progress) }
+                },
+            )
+                .onSuccess { translated ->
+                    // Translate title if enabled
+                    val translatedTitle = if (translateTitle && !_readerState.value.title.isNullOrBlank()) {
+                        translationService.translateText(
+                            text = _readerState.value.title!!,
+                            sourceLanguage = sourceLanguage,
+                            targetLanguage = targetLang,
+                        ).getOrDefault(_readerState.value.title!!)
+                    } else {
+                        _readerState.value.title
+                    }
+                    _readerState.update {
+                        it.copy(
+                            content = when (it.content) {
+                                is ReaderState.Description -> ReaderState.Description(translated)
+                                is ReaderState.FullContent -> ReaderState.FullContent(translated)
+                                else -> it.content
+                            },
+                            title = translatedTitle,
+                            isTranslated = true,
+                            isTranslating = false,
+                            isDownloadingModel = false,
+                            translationProgress = 0f,
+                        )
+                    }
+                }
+                .onFailure {
+                    _readerState.update { it.copy(isTranslating = false, isDownloadingModel = false, translationProgress = 0f) }
+                }
+        }
+    }
+
+    /**
+     * Called when user cancels the model download dialog.
+     */
+    fun cancelTranslation() {
+        _readerState.update {
+            it.copy(
+                needsDownloadConfirmation = false,
+                pendingSourceLanguage = null,
+                isTranslating = false,
+                isDownloadingModel = false,
+                translationProgress = 0f,
+                // Restore original content and title
+                content = it.originalContent ?: it.content,
+                originalContent = null,
+                title = it.originalTitle ?: it.title,
+                originalTitle = null,
+            )
+        }
+    }
+
+    fun showOriginalContent() {
+        val original = _readerState.value.originalContent ?: return
+        _readerState.update {
+            it.copy(
+                content = original,
+                isTranslated = false,
+                originalContent = null,
+                title = it.originalTitle ?: it.title,
+                originalTitle = null,
+            )
+        }
+    }
+
+    fun toggleTranslation(translateTitle: Boolean = true) {
+        if (_readerState.value.isTranslated) {
+            showOriginalContent()
+        } else {
+            translateContent(translateTitle)
+        }
     }
 
     fun ReaderState.prefetchArticleId(): ReaderState {
@@ -465,6 +736,15 @@ data class ReaderState(
     val listIndex: Int? = null,
     val nextArticle: PrefetchResult? = null,
     val previousArticle: PrefetchResult? = null,
+    val isTranslated: Boolean = false,
+    val isTranslating: Boolean = false,
+    val originalContent: ContentState? = null,
+    val originalTitle: String? = null,
+    val detectedLanguage: String? = null,
+    val needsDownloadConfirmation: Boolean = false,
+    val pendingSourceLanguage: String? = null,
+    val isDownloadingModel: Boolean = false,
+    val translationProgress: Float = 0f,
 ) {
     data class PrefetchResult(val articleId: String, val index: Int)
 

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedOptionView.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedOptionView.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.automirrored.outlined.Article
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.OpenInBrowser
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -35,6 +36,7 @@ fun FeedOptionView(
     selectedAllowNotificationPreset: Boolean = false,
     selectedParseFullContentPreset: Boolean = false,
     selectedOpenInBrowserPreset: Boolean = false,
+    selectedAutoTranslatePreset: Boolean = false,
     isMoveToGroup: Boolean = false,
     showGroup: Boolean = true,
     showUnsubscribe: Boolean = true,
@@ -43,6 +45,7 @@ fun FeedOptionView(
     allowNotificationPresetOnClick: () -> Unit = {},
     parseFullContentPresetOnClick: () -> Unit = {},
     openInBrowserPresetOnClick: () -> Unit = {},
+    autoTranslatePresetOnClick: () -> Unit = {},
     clearArticlesOnClick: () -> Unit = {},
     unsubscribeOnClick: () -> Unit = {},
     onGroupClick: (groupId: String) -> Unit = {},
@@ -59,11 +62,13 @@ fun FeedOptionView(
             selectedAllowNotificationPreset = selectedAllowNotificationPreset,
             selectedParseFullContentPreset = selectedParseFullContentPreset,
             selectedOpenInBrowserPreset = selectedOpenInBrowserPreset,
+            selectedAutoTranslatePreset = selectedAutoTranslatePreset,
             showUnsubscribe = showUnsubscribe,
             notSubscribeMode = notSubscribeMode,
             allowNotificationPresetOnClick = allowNotificationPresetOnClick,
             parseFullContentPresetOnClick = parseFullContentPresetOnClick,
             openInBrowserPresetOnClick = openInBrowserPresetOnClick,
+            autoTranslatePresetOnClick = autoTranslatePresetOnClick,
             clearArticlesOnClick = clearArticlesOnClick,
             unsubscribeOnClick = unsubscribeOnClick,
         )
@@ -107,11 +112,13 @@ private fun Preset(
     selectedAllowNotificationPreset: Boolean = false,
     selectedParseFullContentPreset: Boolean = false,
     selectedOpenInBrowserPreset: Boolean = false,
+    selectedAutoTranslatePreset: Boolean = false,
     showUnsubscribe: Boolean = true,
     notSubscribeMode: Boolean = false,
     allowNotificationPresetOnClick: () -> Unit = {},
     parseFullContentPresetOnClick: () -> Unit = {},
     openInBrowserPresetOnClick: () -> Unit = {},
+    autoTranslatePresetOnClick: () -> Unit = {},
     clearArticlesOnClick: () -> Unit = {},
     unsubscribeOnClick: () -> Unit = {},
 ) {
@@ -150,6 +157,23 @@ private fun Preset(
                 },
             ) {
                 openInBrowserPresetOnClick()
+            }
+        }
+        item {
+            RYSelectionChip(
+                modifier = Modifier,
+                content = stringResource(R.string.auto_translate),
+                selected = selectedAutoTranslatePreset,
+                selectedIcon = {
+                    Icon(
+                        modifier = Modifier.padding(start = 8.dp).size(20.dp),
+                        imageVector = Icons.Outlined.Translate,
+                        contentDescription = stringResource(R.string.auto_translate),
+                        tint = MaterialTheme.colorScheme.onSurface alwaysLight true,
+                    )
+                },
+            ) {
+                autoTranslatePresetOnClick()
             }
         }
     }

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionDrawer.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionDrawer.kt
@@ -99,6 +99,7 @@ fun FeedOptionDrawer(
                         ?: false,
                     selectedParseFullContentPreset = feedOptionUiState.feed?.isFullContent ?: false,
                     selectedOpenInBrowserPreset = feedOptionUiState.feed?.isBrowser ?: false,
+                    selectedAutoTranslatePreset = feedOptionUiState.feed?.isTranslate ?: false,
                     isMoveToGroup = true,
                     showGroup = feedOptionViewModel.rssService.get().moveSubscription,
                     showUnsubscribe = feedOptionViewModel.rssService.get().deleteSubscription,
@@ -112,6 +113,9 @@ fun FeedOptionDrawer(
                     },
                     openInBrowserPresetOnClick = {
                         feedOptionViewModel.changeOpenInBrowserPreset()
+                    },
+                    autoTranslatePresetOnClick = {
+                        feedOptionViewModel.changeAutoTranslatePreset()
                     },
                     clearArticlesOnClick = {
                         feedOptionViewModel.showClearDialog()

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionViewModel.kt
@@ -128,6 +128,15 @@ constructor(
         }
     }
 
+    fun changeAutoTranslatePreset() {
+        viewModelScope.launch(ioDispatcher) {
+            _feedOptionUiState.value.feed?.let {
+                rssService.get().updateFeed(it.copy(isTranslate = !it.isTranslate))
+                fetchFeed(it.id)
+            }
+        }
+    }
+
     fun delete(callback: () -> Unit = {}) {
         _feedOptionUiState.value.feed?.let {
             applicationScope.launch(ioDispatcher) {

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/BottomBar.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/BottomBar.kt
@@ -23,16 +23,21 @@ import androidx.compose.material.icons.outlined.Headphones
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material.icons.rounded.StarOutline
+import androidx.compose.material.icons.rounded.Translate
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import me.ash.reader.R
 import me.ash.reader.infrastructure.preference.LocalReadingPageTonalElevation
@@ -52,6 +57,11 @@ fun BottomBar(
     isNextArticleAvailable: Boolean,
     isFullContent: Boolean,
     isBoldCharacters: Boolean,
+    isTranslated: Boolean = false,
+    isTranslating: Boolean = false,
+    isTranslateEnabled: Boolean = false,
+    isDownloadingModel: Boolean = false,
+    translationProgress: Float = 0f,
     ttsButton: @Composable () -> Unit,
     onUnread: (isUnread: Boolean) -> Unit = {},
     onStarred: (isStarred: Boolean) -> Unit = {},
@@ -59,6 +69,7 @@ fun BottomBar(
     onFullContent: (isFullContent: Boolean) -> Unit = {},
     onBoldCharacters: () -> Unit = {},
     onReadAloud: () -> Unit = {},
+    onTranslate: () -> Unit = {},
 ) {
     val tonalElevation = LocalReadingPageTonalElevation.current
     val isOutlined = tonalElevation == ReadingPageTonalElevationPreference.Outlined
@@ -86,6 +97,17 @@ fun BottomBar(
                 Surface(
                     color = MaterialTheme.colorScheme.run { if (isOutlined) surface else surfaceContainer }
                 ) {
+                    Column {
+                        // Download progress indicator
+                        if (isDownloadingModel) {
+                            LinearProgressIndicator(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(3.dp),
+                                color = MaterialTheme.colorScheme.primary,
+                                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                            )
+                        }
                     // TODO: Component styles await refactoring
                     Row(
                         modifier = Modifier
@@ -142,6 +164,48 @@ fun BottomBar(
                             onNextArticle()
                         }
                         ttsButton()
+                        if (isTranslateEnabled) {
+                            CanBeDisabledIconButton(
+                                disabled = isTranslating,
+                                modifier = Modifier.size(40.dp),
+                                imageVector = if (isTranslating) null else Icons.Rounded.Translate,
+                                icon = {
+                                    if (isTranslating) {
+                                        Box(
+                                            contentAlignment = Alignment.Center,
+                                            modifier = Modifier.size(24.dp),
+                                        ) {
+                                            CircularProgressIndicator(
+                                                progress = { translationProgress },
+                                                modifier = Modifier.fillMaxSize(),
+                                                strokeWidth = 2.dp,
+                                                color = MaterialTheme.colorScheme.primary,
+                                                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                                            )
+                                            Text(
+                                                text = "${(translationProgress * 100).toInt()}%",
+                                                style = MaterialTheme.typography.labelSmall.copy(
+                                                    fontSize = 7.sp,
+                                                    lineHeight = 7.sp,
+                                                ),
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                    }
+                                },
+                                contentDescription = stringResource(
+                                    if (isTranslated) R.string.show_original else R.string.translate
+                                ),
+                                tint = if (isTranslated) {
+                                    MaterialTheme.colorScheme.onSecondaryContainer
+                                } else {
+                                    MaterialTheme.colorScheme.outline
+                                },
+                            ) {
+                                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                                onTranslate()
+                            }
+                        }
                         CanBeDisabledIconButton(
                             disabled = false,
                             modifier = Modifier.size(40.dp),
@@ -160,6 +224,7 @@ fun BottomBar(
                             view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                             onFullContent(!isFullContent)
                         }
+                    }
                     }
                 }
             }

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.sp
 import kotlin.math.abs
+import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
 import me.ash.reader.R
 import me.ash.reader.infrastructure.android.TextToSpeechManager
@@ -47,7 +48,10 @@ import me.ash.reader.infrastructure.preference.LocalPullToSwitchArticle
 import me.ash.reader.infrastructure.preference.LocalReadingAutoHideToolbar
 import me.ash.reader.infrastructure.preference.LocalReadingBoldCharacters
 import me.ash.reader.infrastructure.preference.LocalReadingTextLineHeight
+import me.ash.reader.infrastructure.preference.LocalTranslateArticle
+import me.ash.reader.infrastructure.preference.LocalTranslateTitle
 import me.ash.reader.infrastructure.preference.not
+import me.ash.reader.ui.component.base.RYDialog
 import me.ash.reader.ui.ext.collectAsStateValue
 import me.ash.reader.ui.ext.showToast
 import me.ash.reader.ui.page.adaptive.ArticleListReaderViewModel
@@ -74,6 +78,8 @@ fun ReadingPage(
     val readingUiState = viewModel.readingUiState.collectAsStateValue()
     val readerState = viewModel.readerStateStateFlow.collectAsStateValue()
     val boldCharacters = LocalReadingBoldCharacters.current
+    val translateGlobalEnabled = LocalTranslateArticle.current.value
+    val translateTitleEnabled = LocalTranslateTitle.current.value
     val coroutineScope = rememberCoroutineScope()
 
     var isReaderScrollingDown by remember { mutableStateOf(false) }
@@ -169,6 +175,7 @@ fun ReadingPage(
                                         tween(durationMillis = exit, easing = FastOutLinearInEasing)
                                     ))
                         },
+                        contentKey = { listOf(it.articleId, it.content::class, it.listIndex, it.isTranslated) },
                         label = "",
                     ) {
                         remember { it }
@@ -253,13 +260,13 @@ fun ReadingPage(
                                                     enabled = isPullToSwitchArticleEnabled,
                                                 ),
                                             contentPadding = paddings,
-                                            content = content.text ?: "",
+                                            content = readerState.content.text ?: "",
                                             feedName = feedName,
-                                            title = title.toString(),
+                                            title = readerState.title.toString(),
                                             author = author,
                                             link = link,
                                             publishedDate = publishedDate,
-                                            isLoading = content is ReaderState.Loading,
+                                            isLoading = readerState.content is ReaderState.Loading,
                                             scrollState = scrollState,
                                             listState = listState,
                                             onImageClick = { imgUrl, altText ->
@@ -288,6 +295,11 @@ fun ReadingPage(
                             readerState.content is ReaderState.FullContent ||
                                 readerState.content is ReaderState.Error,
                         isBoldCharacters = boldCharacters.value,
+                        isTranslated = readerState.isTranslated,
+                        isTranslating = readerState.isTranslating,
+                        isTranslateEnabled = translateGlobalEnabled,
+                        isDownloadingModel = readerState.isDownloadingModel,
+                        translationProgress = readerState.translationProgress,
                         onUnread = { viewModel.updateReadStatus(it) },
                         onStarred = { viewModel.updateStarredStatus(it) },
                         onNextArticle = {
@@ -297,8 +309,8 @@ fun ReadingPage(
                             }
                         },
                         onFullContent = {
-                            if (it) viewModel.renderFullContent()
-                            else viewModel.renderDescriptionContent()
+                            if (it) viewModel.renderFullContent(translateTitleEnabled)
+                            else viewModel.renderDescriptionContent(translateTitleEnabled)
                         },
                         onBoldCharacters = { (!boldCharacters).put(context, coroutineScope) },
                         onReadAloud = {
@@ -333,6 +345,9 @@ fun ReadingPage(
                                     viewModel.textToSpeechManager.stateFlow.collectAsStateValue(),
                             )
                         },
+                        onTranslate = {
+                            viewModel.toggleTranslation(translateTitleEnabled)
+                        },
                     )
                 }
             }
@@ -356,4 +371,34 @@ fun ReadingPage(
             onDismissRequest = { showFullScreenImageViewer = false },
         )
     }
+
+    // Model download confirmation dialog
+    RYDialog(
+        visible = readerState.needsDownloadConfirmation,
+        onDismissRequest = { viewModel.cancelTranslation() },
+        title = {
+            androidx.compose.material3.Text(
+                text = stringResource(R.string.download_model_title)
+            )
+        },
+        text = {
+            androidx.compose.material3.Text(
+                text = stringResource(R.string.download_model_message)
+            )
+        },
+        confirmButton = {
+            androidx.compose.material3.TextButton(
+                onClick = { viewModel.confirmDownloadAndTranslate(translateTitleEnabled) }
+            ) {
+                androidx.compose.material3.Text(text = stringResource(R.string.confirm))
+            }
+        },
+        dismissButton = {
+            androidx.compose.material3.TextButton(
+                onClick = { viewModel.cancelTranslation() }
+            ) {
+                androidx.compose.material3.Text(text = stringResource(R.string.cancel))
+            }
+        },
+    )
 }

--- a/app/src/main/java/me/ash/reader/ui/page/nav3/AppEntry.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/nav3/AppEntry.kt
@@ -51,6 +51,9 @@ import me.ash.reader.ui.page.settings.interaction.InteractionPage
 import me.ash.reader.ui.page.settings.languages.LanguagesPage
 import me.ash.reader.ui.page.settings.tips.LicenseListPage
 import me.ash.reader.ui.page.settings.tips.TipsAndSupportPage
+import me.ash.reader.ui.page.settings.translation.TranslationPage
+import me.ash.reader.ui.page.settings.translation.TranslationTargetLanguagePage
+import me.ash.reader.ui.page.settings.translation.TranslationTargetLanguagePage
 import me.ash.reader.ui.page.settings.troubleshooting.TroubleshootingPage
 import me.ash.reader.ui.page.startup.StartupPage
 
@@ -184,6 +187,7 @@ fun AppEntry(backStack: NavBackStack<NavKey>) {
                                 navigateToColorAndStyle = { backStack.add(Route.ColorAndStyle) },
                                 navigateToInteraction = { backStack.add(Route.Interaction) },
                                 navigateToLanguages = { backStack.add(Route.Languages) },
+                                navigateToTranslation = { backStack.add(Route.Translation) },
                                 navigateToTroubleshooting = {
                                     backStack.add(Route.Troubleshooting)
                                 },
@@ -264,6 +268,17 @@ fun AppEntry(backStack: NavBackStack<NavKey>) {
                     Route.ReadingPageVideo -> NavEntry(key) { ReadingVideoPage(onBack = onBack) }
                     Route.Interaction -> NavEntry(key) { InteractionPage(onBack = onBack) }
                     Route.Languages -> NavEntry(key) { LanguagesPage(onBack = onBack) }
+                    Route.Translation ->
+                        NavEntry(key) {
+                            TranslationPage(
+                                onBack = onBack,
+                                onNavigateToTargetLanguage = {
+                                    backStack.add(Route.TranslationTargetLanguage)
+                                },
+                            )
+                        }
+                    Route.TranslationTargetLanguage ->
+                        NavEntry(key) { TranslationTargetLanguagePage(onBack = onBack) }
                     Route.Troubleshooting -> NavEntry(key) { TroubleshootingPage(onBack = onBack) }
                     Route.TipsAndSupport ->
                         NavEntry(key) {

--- a/app/src/main/java/me/ash/reader/ui/page/nav3/key/NavKey.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/nav3/key/NavKey.kt
@@ -58,6 +58,10 @@ sealed interface Route : NavKey {
     // Languages
     @Serializable data object Languages : Route
 
+    // Translation
+    @Serializable data object Translation : Route
+    @Serializable data object TranslationTargetLanguage : Route
+
     // Troubleshooting
     @Serializable data object Troubleshooting : Route
 

--- a/app/src/main/java/me/ash/reader/ui/page/settings/SettingsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/SettingsPage.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.outlined.Lightbulb
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.TipsAndUpdates
 import androidx.compose.material.icons.outlined.TouchApp
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -51,6 +52,7 @@ fun SettingsPage(
     navigateToColorAndStyle: () -> Unit,
     navigateToInteraction: () -> Unit,
     navigateToLanguages: () -> Unit,
+    navigateToTranslation: () -> Unit,
     navigateToTroubleshooting: () -> Unit,
     navigateToTipsAndSupport: () -> Unit,
 ) {
@@ -133,6 +135,14 @@ fun SettingsPage(
                         desc = Locale.getDefault().toDisplayName(),
                         icon = Icons.Outlined.Language,
                         onClick = navigateToLanguages
+                    )
+                }
+                item {
+                    SelectableSettingGroupItem(
+                        title = stringResource(R.string.translation),
+                        desc = stringResource(R.string.translation_desc),
+                        icon = Icons.Outlined.Translate,
+                        onClick = navigateToTranslation
                     )
                 }
                 item {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/translation/TranslationPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/translation/TranslationPage.kt
@@ -1,0 +1,188 @@
+package me.ash.reader.ui.page.settings.translation
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.outlined.CleaningServices
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import me.ash.reader.R
+import me.ash.reader.infrastructure.preference.LocalTranslateArticle
+import me.ash.reader.infrastructure.preference.LocalTranslateTitle
+import me.ash.reader.infrastructure.preference.LocalTranslateTargetLanguage
+import me.ash.reader.infrastructure.preference.LocalTranslateWifiOnly
+import me.ash.reader.infrastructure.preference.TranslateArticlePreference
+import me.ash.reader.infrastructure.preference.not
+import me.ash.reader.ui.component.base.DisplayText
+import me.ash.reader.ui.component.base.FeedbackIconButton
+import me.ash.reader.ui.component.base.RYDialog
+import me.ash.reader.ui.component.base.RYScaffold
+import me.ash.reader.ui.page.settings.SettingItem
+import me.ash.reader.ui.theme.palette.onLight
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.Text
+import java.util.Locale
+
+@Composable
+fun TranslationPage(
+    onBack: () -> Unit,
+    onNavigateToTargetLanguage: () -> Unit,
+    viewModel: TranslationSettingsViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val translateArticle = LocalTranslateArticle.current
+    val translateTitle = LocalTranslateTitle.current
+    val translateTargetLanguage = LocalTranslateTargetLanguage.current
+    val translateWifiOnly = LocalTranslateWifiOnly.current
+    val downloadedModels by viewModel.downloadedModels.collectAsStateWithLifecycle()
+    val modelToDelete by viewModel.modelToDelete.collectAsStateWithLifecycle()
+
+    RYScaffold(
+        containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
+        navigationIcon = {
+            FeedbackIconButton(
+                imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                contentDescription = stringResource(R.string.back),
+                tint = MaterialTheme.colorScheme.onSurface,
+                onClick = onBack
+            )
+        },
+        content = {
+            LazyColumn {
+                item {
+                    DisplayText(text = stringResource(R.string.translation), desc = "")
+                }
+                item {
+                    SettingItem(
+                        title = stringResource(R.string.translate_article),
+                        desc = stringResource(R.string.translation_desc),
+                        onClick = {
+                            (!translateArticle).put(context, scope)
+                        },
+                    ) {
+                        Switch(
+                            checked = translateArticle.value,
+                            onCheckedChange = {
+                                (!translateArticle).put(context, scope)
+                            }
+                        )
+                    }
+                }
+                item {
+                    SettingItem(
+                        title = stringResource(R.string.translate_title),
+                        onClick = {
+                            (!translateTitle).put(context, scope)
+                        },
+                    ) {
+                        Switch(
+                            checked = translateTitle.value,
+                            onCheckedChange = {
+                                (!translateTitle).put(context, scope)
+                            }
+                        )
+                    }
+                }
+                item {
+                    SettingItem(
+                        title = stringResource(R.string.translate_target_language),
+                        desc = translateTargetLanguage.toDesc(),
+                        icon = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                        onClick = onNavigateToTargetLanguage
+                    )
+                }
+                item {
+                    SettingItem(
+                        title = stringResource(R.string.translate_wifi_only),
+                        onClick = {
+                            (!translateWifiOnly).put(context, scope)
+                        },
+                    ) {
+                        Switch(
+                            checked = translateWifiOnly.value,
+                            onCheckedChange = {
+                                (!translateWifiOnly).put(context, scope)
+                            }
+                        )
+                    }
+                }
+                item {
+                    DisplayText(text = stringResource(R.string.manage_models), desc = "")
+                }
+                if (downloadedModels.isEmpty()) {
+                    item {
+                        SettingItem(
+                            title = stringResource(R.string.no_downloaded_models),
+                            onClick = {}
+                        )
+                    }
+                } else {
+                    items(downloadedModels.size) { index ->
+                        val model = downloadedModels[index]
+                        val name = Locale.forLanguageTag(model).displayName
+                        SettingItem(
+                            title = name,
+                            desc = model,
+                            onClick = {}
+                        ) {
+                            IconButton(onClick = { viewModel.requestDeleteModel(model) }) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Delete,
+                                    contentDescription = stringResource(R.string.delete_model)
+                                )
+                            }
+                        }
+                    }
+                }
+                item {
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+                }
+            }
+        }
+    )
+
+    if (modelToDelete != null) {
+        RYDialog(
+            visible = true,
+            onDismissRequest = { viewModel.cancelDelete() },
+            title = {
+                Text(text = stringResource(R.string.delete_model_title))
+            },
+            text = {
+                val name = Locale.forLanguageTag(modelToDelete!!).displayName
+                Text(text = stringResource(R.string.delete_model_confirmation, name))
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.confirmDelete() }
+                ) {
+                    Text(text = stringResource(R.string.delete))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { viewModel.cancelDelete() }
+                ) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/page/settings/translation/TranslationSettingsViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/translation/TranslationSettingsViewModel.kt
@@ -1,0 +1,53 @@
+package me.ash.reader.ui.page.settings.translation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import me.ash.reader.infrastructure.translation.TranslationService
+import javax.inject.Inject
+
+@HiltViewModel
+class TranslationSettingsViewModel @Inject constructor(
+    private val translationService: TranslationService
+) : ViewModel() {
+
+    private val _downloadedModels = MutableStateFlow<List<String>>(emptyList())
+    val downloadedModels: StateFlow<List<String>> = _downloadedModels.asStateFlow()
+
+    private val _modelToDelete = MutableStateFlow<String?>(null)
+    val modelToDelete: StateFlow<String?> = _modelToDelete.asStateFlow()
+
+    init {
+        refreshDownloadedModels()
+    }
+
+    private fun refreshDownloadedModels() {
+        viewModelScope.launch {
+            _downloadedModels.value = translationService.getDownloadedModels()
+        }
+    }
+
+    fun requestDeleteModel(languageTag: String) {
+        _modelToDelete.value = languageTag
+    }
+
+    fun cancelDelete() {
+        _modelToDelete.value = null
+    }
+
+    fun confirmDelete() {
+        val model = _modelToDelete.value ?: return
+        viewModelScope.launch {
+            runCatching {
+                translationService.deleteModel(model)
+            }.onSuccess {
+                refreshDownloadedModels()
+                _modelToDelete.value = null
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/page/settings/translation/TranslationTargetLanguagePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/translation/TranslationTargetLanguagePage.kt
@@ -1,0 +1,74 @@
+package me.ash.reader.ui.page.settings.translation
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import me.ash.reader.R
+import me.ash.reader.infrastructure.preference.LocalTranslateTargetLanguage
+import me.ash.reader.infrastructure.preference.TranslateTargetLanguagePreference
+import me.ash.reader.ui.component.base.DisplayText
+import me.ash.reader.ui.component.base.FeedbackIconButton
+import me.ash.reader.ui.component.base.RYScaffold
+import me.ash.reader.ui.page.settings.SettingItem
+import me.ash.reader.ui.theme.palette.onLight
+
+@Composable
+fun TranslationTargetLanguagePage(
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val currentPreference = LocalTranslateTargetLanguage.current
+    val scope = rememberCoroutineScope()
+
+    RYScaffold(
+        containerColor = MaterialTheme.colorScheme.surface onLight MaterialTheme.colorScheme.inverseOnSurface,
+        navigationIcon = {
+            FeedbackIconButton(
+                imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                contentDescription = stringResource(R.string.back),
+                tint = MaterialTheme.colorScheme.onSurface,
+                onClick = onBack
+            )
+        },
+        content = {
+            LazyColumn {
+                item {
+                    DisplayText(text = stringResource(R.string.translate_target_language), desc = "")
+                }
+                items(TranslateTargetLanguagePreference.values) { preference ->
+                    SettingItem(
+                        title = preference.toDesc(),
+                        onClick = {
+                            preference.put(context, scope)
+                        },
+                    ) {
+                        RadioButton(
+                            selected = preference == currentPreference,
+                            onClick = {
+                                preference.put(context, scope)
+                            }
+                        )
+                    }
+                }
+                item {
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,4 +386,27 @@
     <string name="parse_full_content_desc">Fetch full articles from webpages</string>
     <string name="enable">Enable</string>
     <string name="disable">Disable</string>
+
+    <!-- Translation -->
+    <string name="translate">Translate</string>
+    <string name="translation">Translation</string>
+    <string name="translation_desc">Translate articles, manage language models</string>
+    <string name="translate_article">Translate articles</string>
+    <string name="translate_title">Translate titles</string>
+    <string name="auto_translate">Auto-translate</string>
+    <string name="show_original">Show original</string>
+    <string name="translating">Translating…</string>
+    <string name="translation_model_downloading">Downloading language model…</string>
+    <string name="translation_model_download_failed">Language model download failed</string>
+    <string name="downloaded_models">Downloaded models</string>
+    <string name="delete_model">Delete model</string>
+    <string name="no_downloaded_models">No downloaded models</string>
+    <string name="translate_target_language">Target language</string>
+    <string name="translate_wifi_only">Download over Wi-Fi only</string>
+    <string name="manage_models">Manage models</string>
+    <string name="delete_model_desc">Delete downloaded language model</string>
+    <string name="delete_model_title">Delete Model</string>
+    <string name="delete_model_confirmation">Are you sure you want to delete the %1$s model?</string>
+    <string name="download_model_title">Download Translation Models</string>
+    <string name="download_model_message">Translation models (~30 MB each) need to be downloaded to translate this article. Continue?</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,8 @@ telephoto = "0.15.1"
 swipe = "1.3.0"
 timber = "5.0.1"
 glance = "1.2.0-beta01"
+mlkitTranslate = "17.0.3"
+mlkitLanguageId = "17.0.0"
 
 nav3 = "1.0.0"
 kotlinxSerializationCore = "1.9.0"
@@ -90,7 +92,7 @@ hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hilt" 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "dagger" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "dagger" }
 hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hilt" }
-hilt-viewmodel = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hilt" }
+hilt-viewmodel = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt" }
 
 # AndroidX
 android-svg = { group = "com.caverock", name = "androidsvg-aar", version.ref = "androidSVG" }
@@ -117,6 +119,7 @@ paging-compose = { group = "androidx.paging", name = "paging-compose", version.r
 browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -140,6 +143,8 @@ compose-material3-adaptive-navigation3 = { group = "androidx.compose.material3.a
 
 
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
+mlkit-translate = { group = "com.google.mlkit", name = "translate", version.ref = "mlkitTranslate" }
+mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version.ref = "mlkitLanguageId" }
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
### Translation Feature: On-Device & Offline Support
I've added a new translation feature to the app that works entirely on-device using ML Kit. This allows users to translate articles without sending data to any external servers, maintaining privacy and enabling offline use once the language models are downloaded.

### Key Changes

- On-Device Translation: Implemented using ML Kit. The app detects the source language and translates it to the user's preferred target language (It's still a bit bugy, but it's fixable)
- UI Integration: Added a "Translate" button to the reader view. It's designed to be unobtrusive and easy to toggle.
- Seamless Reading: The translation state persists when switching between the RSS summary (Description) and the full article content. If you're reading a translated summary and switch to the full article, it automatically translates the new content so you don't lose your place.
- Title Translation: Added an option in settings to translate article titles as well, which is useful when browsing foreign feeds.
- Offline Support: The app manages language model downloads (about 30MB each). Users are prompted to download a model if it's missing.
- No Flicker: Spent time optimizing the view updates so the screen doesn't flicker when switching between languages.

### Settings
Added a new "Translation" section in settings where users can:

- Select their target language.
- Toggle title translation.
- Choose to download models only over Wi-Fi.
- Manage downloaded models.
