### PR TITLE
add "open in browser" buttons to reading page and article list

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.rounded.ArrowDownward
 import androidx.compose.material.icons.rounded.ArrowUpward
 import androidx.compose.material.icons.rounded.CheckCircleOutline
 import androidx.compose.material.icons.rounded.FiberManualRecord
+import androidx.compose.material.icons.rounded.OpenInBrowser
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material3.DropdownMenuItem
@@ -320,6 +321,7 @@ fun SwipeableArticleItem(
     onMarkAboveAsRead: ((ArticleWithFeed) -> Unit)? = null,
     onMarkBelowAsRead: ((ArticleWithFeed) -> Unit)? = null,
     onShare: ((ArticleWithFeed) -> Unit)? = null,
+    onOpenInBrowser: ((ArticleWithFeed) -> Unit)? = null,
 ) {
 
     var isMenuExpanded by remember { mutableStateOf(false) }
@@ -381,6 +383,7 @@ fun SwipeableArticleItem(
                             onMarkAboveAsRead = onMarkAboveAsRead,
                             onMarkBelowAsRead = onMarkBelowAsRead,
                             onShare = onShare,
+                            onOpenInBrowser = onOpenInBrowser
                         ) {
                             isMenuExpanded = false
                         }
@@ -571,6 +574,7 @@ fun ArticleItemMenuContent(
     onMarkAboveAsRead: ((ArticleWithFeed) -> Unit)? = null,
     onMarkBelowAsRead: ((ArticleWithFeed) -> Unit)? = null,
     onShare: ((ArticleWithFeed) -> Unit)? = null,
+    onOpenInBrowser: ((ArticleWithFeed) -> Unit)? = null,
     onItemClick: (() -> Unit)? = null,
 ) {
     val starImageVector =
@@ -667,6 +671,22 @@ fun ArticleItemMenuContent(
             },
         )
     }
+    onOpenInBrowser?.let {
+        DropdownMenuItem(
+            text = { Text(text = stringResource(id = R.string.open_in_browser)) },
+            onClick = {
+                onOpenInBrowser(articleWithFeed)
+                onItemClick?.invoke()
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Rounded.OpenInBrowser,
+                    contentDescription = null,
+                    modifier = Modifier.size(iconSize)
+                )
+            },
+        )
+    }
 }
 
 @Preview
@@ -680,6 +700,7 @@ fun MenuContentPreview() {
                     onMarkBelowAsRead = {},
                     onMarkAboveAsRead = {},
                     onShare = {},
+                    onOpenInBrowser = {}
                 )
             }
         }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleList.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleList.kt
@@ -29,6 +29,7 @@ fun LazyListScope.ArticleList(
     onMarkAboveAsRead: ((ArticleWithFeed) -> Unit)? = null,
     onMarkBelowAsRead: ((ArticleWithFeed) -> Unit)? = null,
     onShare: ((ArticleWithFeed) -> Unit)? = null,
+    onOpenInBrowser: ((ArticleWithFeed) -> Unit)? = null,
 ) {
     // https://issuetracker.google.com/issues/193785330
     // FIXME: Using sticky header with paging-compose need to iterate through the entire list
@@ -57,6 +58,7 @@ fun LazyListScope.ArticleList(
                         onMarkBelowAsRead =
                             if (index == pagingItems.itemCount - 1) null else onMarkBelowAsRead,
                         onShare = onShare,
+                        onOpenInBrowser = onOpenInBrowser,
                     )
                 }
 
@@ -91,6 +93,7 @@ fun LazyListScope.ArticleList(
                             onMarkBelowAsRead =
                                 if (index == pagingItems.itemCount - 1) null else onMarkBelowAsRead,
                             onShare = onShare,
+                            onOpenInBrowser = onOpenInBrowser
                         )
                     }
                 }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -131,6 +132,7 @@ fun FlowPage(
     val filterBarPadding = LocalFlowFilterBarPadding.current
     val filterBarTonalElevation = LocalFlowFilterBarTonalElevation.current
     val sharedContent = LocalSharedContent.current
+    val uriHandler = LocalUriHandler.current
     val markAsReadOnScroll = LocalMarkAsReadOnScroll.current.value
     val context = LocalContext.current
 
@@ -216,6 +218,12 @@ fun FlowPage(
     val onShare: ((ArticleWithFeed) -> Unit)? = remember {
         { articleWithFeed ->
             with(articleWithFeed.article) { sharedContent.share(context, title, link) }
+        }
+    }
+
+    val onOpenInBrowser: ((ArticleWithFeed) -> Unit)? = remember {
+        { articleWithFeed ->
+            with(articleWithFeed.article) { uriHandler.openUri(link) }
         }
     }
 
@@ -692,6 +700,7 @@ fun FlowPage(
                                 onMarkAboveAsRead = onMarkAboveAsRead,
                                 onMarkBelowAsRead = onMarkBelowAsRead,
                                 onShare = onShare,
+                                onOpenInBrowser = onOpenInBrowser,
                             )
                             item {
                                 Spacer(modifier = Modifier.height(128.dp))

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/TopBar.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/TopBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.MenuOpen
+import androidx.compose.material.icons.outlined.OpenInBrowser
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.rounded.Close
@@ -38,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -65,6 +67,7 @@ fun TopBar(
 ) {
     val context = LocalContext.current
     val sharedContent = LocalSharedContent.current
+    val uriHandler = LocalUriHandler.current
     val isOutlined =
         LocalReadingPageTonalElevation.current == ReadingPageTonalElevationPreference.Outlined
 
@@ -137,6 +140,14 @@ fun TopBar(
                             tint = MaterialTheme.colorScheme.onSurface,
                         ) {
                             sharedContent.share(context, title, link)
+                        }
+                        FeedbackIconButton(
+                            modifier = Modifier.size(22.dp),
+                            imageVector = Icons.Outlined.OpenInBrowser,
+                            contentDescription = stringResource(R.string.open_in_browser),
+                            tint = MaterialTheme.colorScheme.onSurface
+                        ) {
+                            uriHandler.openUri(link!!)
                         }
                     },
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),


### PR DESCRIPTION
the only real problem i've had with this app is the lack of an "open in browser" button; specifically in the case of feeds i'm subscribed to that don't have the article content within the actual feed, necessitating that i open them in a browser. until now i copied article links with the share button and manually opened them in my browser.

this PR just adds a button to the top bar on the reading page and to the context menu of articles in the article list.

also, sorry for not using the typical commit message style, i hate LLMs/vibecoding with a passion and want this to seem like a human actually put effort into it (given the codebase and lack of android dev experience it did take like an hour for me to figure this out); all LLMs do the whole `fix(X)` and `chore: ` stuff, gotta protest it somehow, y'know ;3

btw, in terms of actual discussion of the content of the PR, i was unsure whether to put the "open in browser" button on the left or right of the share button (and so also above or below the share button in the context menu). if you think a different order makes more sense then feel free to change it without asking, whatever works for me honestly as long as the button is there x3