### PR TITLE
feat: capitalize first character in create new group text field

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -21,6 +22,7 @@ fun ClipboardTextField(
     isPassword: Boolean = false,
     errorText: String = "",
     imeAction: ImeAction = ImeAction.Done,
+    capitalization: KeyboardCapitalization = KeyboardCapitalization.None,
     onConfirm: (String) -> Unit = {},
 ) {
     Column(modifier = Modifier) {
@@ -37,7 +39,7 @@ fun ClipboardTextField(
                 if (imeAction != ImeAction.Default || imeAction != ImeAction.None) {
                     KeyboardActionHandler { onConfirm(state.text.toString()) }
                 } else null,
-            keyboardOptions = KeyboardOptions(imeAction = imeAction),
+            keyboardOptions = KeyboardOptions(imeAction = imeAction, capitalization = capitalization),
         )
         Spacer(modifier = Modifier.height(10.dp))
     }

--- a/app/src/main/java/me/ash/reader/ui/component/base/TextFieldDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/TextFieldDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.window.DialogProperties
 import me.ash.reader.R
@@ -41,6 +42,7 @@ fun TextFieldDialog(
     onDismissRequest: () -> Unit = {},
     onConfirm: (String) -> Unit = {},
     imeAction: ImeAction = if (singleLine) ImeAction.Done else ImeAction.Default,
+    capitalization: KeyboardCapitalization = KeyboardCapitalization.None,
 ) {
     val focusManager = LocalFocusManager.current
     val textFieldState = rememberTextFieldState(value)
@@ -66,6 +68,7 @@ fun TextFieldDialog(
                 isPassword = isPassword,
                 errorText = errorText,
                 imeAction = imeAction,
+                capitalization = capitalization,
                 onConfirm = onConfirm,
             )
         },

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionDrawer.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionDrawer.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -163,7 +164,8 @@ fun FeedOptionDrawer(
         },
         onConfirm = {
             feedOptionViewModel.addNewGroup()
-        }
+        },
+        capitalization = KeyboardCapitalization.Sentences,
     )
 
     RenameDialog(

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
@@ -246,7 +247,8 @@ fun SubscribeDialog(
             },
             onConfirm = {
                 subscribeViewModel.addNewGroup()
-            }
+            },
+            capitalization = KeyboardCapitalization.Sentences,
         )
     }
 }


### PR DESCRIPTION
## PR Summary: Auto-capitalize first character in "Create New Group" text field

**Problem**

When tapping the `+` button under "Move to Group" to create a new group/category, the keyboard appeared without sentence capitalization — the user had to manually capitalize the first letter of the group name.

**Root Cause**

[ClipboardTextField](cci:1://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt:14:0-45:1) was building `KeyboardOptions` with only `imeAction` set, leaving `capitalization` unspecified (defaults to `KeyboardCapitalization.None`). This propagated all the way down to the `TextField` composable shown in the dialog.

**Changes**

- **[ClipboardTextField.kt](cci:7://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt:0:0-0:0)** — Added a `capitalization: KeyboardCapitalization` parameter (default `None`) and wired it into the `KeyboardOptions` passed to [RYTextField2](cci:1://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/component/base/RYTextField.kt:87:0-127:1). This keeps the change opt-in and non-breaking for all existing callers (e.g. URL fields).

- **[TextFieldDialog.kt](cci:7://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/component/base/TextFieldDialog.kt:0:0-0:0)** — Added a `capitalization` parameter (default `None`) to the deprecated `String`-based overload and forwarded it to [ClipboardTextField](cci:1://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt:14:0-45:1).

- **[FeedOptionDrawer.kt](cci:7://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionDrawer.kt:0:0-0:0)** — Passes `KeyboardCapitalization.Sentences` to the "Create New Group" [TextFieldDialog](cci:1://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/component/base/TextFieldDialog.kt:97:0-159:1), so the keyboard auto-capitalizes the first letter when opening the dialog from the feed options drawer.

- **[SubscribeDialog.kt](cci:7://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeDialog.kt:0:0-0:0)** — Same fix applied to the "Create New Group" [TextFieldDialog](cci:1://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/component/base/TextFieldDialog.kt:97:0-159:1) in the subscribe/add feed flow.

**Scope**

Only the two group-name entry dialogs are affected. All other [ClipboardTextField](cci:1://file:///Users/akiumarsi/Documents/ReadYou/app/src/main/java/me/ash/reader/ui/component/base/ClipboardTextField.kt:14:0-45:1) usages (feed URL input, etc.) retain `KeyboardCapitalization.None` since no `capitalization` argument is passed.