### PR TITLE
fix: encode referer header to fix #1206

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/base/RYAsyncImage.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/RYAsyncImage.kt
@@ -41,7 +41,8 @@ fun RYAsyncImage(
                     .apply {
                         val domain = data.toString().extractDomain()
                         if (data.toString().extractDomain() != null) {
-                            addHeader("Referer", domain!!)
+                            val safeDomain = Uri.encode(domain)
+                            addHeader("Referer", safeDomain)
                         }
                     }
                     .data(data = data)

--- a/app/src/main/java/me/ash/reader/ui/component/base/RYAsyncImage.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/RYAsyncImage.kt
@@ -19,6 +19,7 @@ import coil.size.Precision
 import coil.size.Scale
 import coil.size.Size
 import me.ash.reader.ui.ext.extractDomain
+import android.net.Uri 
 
 val SIZE_1000 = Size(1000, 1000)
 


### PR DESCRIPTION
Encode referer header to avoid crashing when header includes non-ASCII characters.