### PR TITLE
fix(greader): stop sync from undoing mark all as read

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -773,6 +773,26 @@ constructor(
     ) {
         val accountId = accountService.getCurrentAccountId()
         val googleReaderAPI = getGoogleReaderAPI()
+
+        // The server can have unread items we don't have locally yet. Marking by ID
+        // misses those, and the next sync flips them back to unread. Mark the whole
+        // stream on the server instead using markAllAsRead.
+        if (!isUnread && articleId == null) {
+            val streamTag =
+                when {
+                    groupId != null ->
+                        GoogleReaderAPI.Stream.Category(groupId.dollarLast()).tag
+                    feedId != null -> GoogleReaderAPI.Stream.Feed(feedId.dollarLast()).tag
+                    else -> GoogleReaderAPI.Stream.AllItems.tag
+                }
+            super.markAsRead(groupId, feedId, articleId, before, isUnread)
+            googleReaderAPI.markAllAsRead(
+                streamId = streamTag,
+                sinceTimestamp = before?.time?.times(1000L),
+            )
+            return
+        }
+
         val markList: List<String> =
             when {
                 groupId != null -> {


### PR DESCRIPTION
## Summary

*   Fixes "Mark all as read" silently leaving items unread on the server, observed against a Miniflux backend over the Google Reader API.
*   Switches the bulk path in `GoogleReaderRssService.markAsRead` from per-ID `edit-tag` calls to the server's `mark-all-as-read` stream endpoint.

## Why

The old flow pushed only IDs the local database knew about. Articles unread on the server but missing locally (pagination, archive, mid-sync) stayed unread, and the next sync flipped them back to unread on the client - producing the `515 → 0 → 1796 → 0 → 515` cycle described in #1271 and mentioned/related to https://github.com/ReadYouApp/ReadYou/issues/1157#issuecomment-3832101605

## Scope

*   **Bulk mark-as-read** (with optional `before` timestamp): now uses `googleReaderAPI.markAllAsRead(streamId, ts)` against `AllItems` / `Feed` / `Category`.
*   **Single-article toggle** and **mark-as-unread**: unchanged - still per-ID `editTag`.

The endpoint is part of the standard Google Reader API. Verified against Miniflux only; behavior against other Google Reader / FreshRSS backends has not been tested but should be no worse than the current per-ID approach.

Closes #1271

## Tested

*   [x] Miniflux account: mark all as read → app shows 0, web UI shows 0, pull-to-refresh keeps it at 0.
*   [x] Mark a single article unread → still works.
*   [x] Mark all in a single feed → only that feed clears.
*   [x] Mark all in a group → only that group clears.
*   [x] Mark as read with the "1 day / 3 days / 7 days" filter → only items older than the cutoff are marked.