### PR TITLE
fix(webview): drop allowFileAccessFromFileURLs in reader WebView

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -30,13 +30,10 @@ object WebViewLayout {
                         ReadingFontsPreference.SansSerif -> "sans-serif"
                         ReadingFontsPreference.Serif -> "serif"
                         ReadingFontsPreference.GoogleSans -> {
-                            allowFileAccess = true
-                            allowFileAccessFromFileURLs = true
                             "sans-serif"
                         }
                         ReadingFontsPreference.External -> {
                             allowFileAccess = true
-                            allowFileAccessFromFileURLs = true
                             "sans-serif"
                         }
 


### PR DESCRIPTION
Closes #1276.

`WebViewLayout.get()` enables two `WebSettings` flags for the `GoogleSans` and `External` reading-fonts preferences:

```kotlin
ReadingFontsPreference.GoogleSans -> {
    allowFileAccess = true
    allowFileAccessFromFileURLs = true
    "sans-serif"
}
ReadingFontsPreference.External -> {
    allowFileAccess = true
    allowFileAccessFromFileURLs = true
    "sans-serif"
}
```

Why this PR removes some of them:

- `allowFileAccessFromFileURLs = true` only takes effect on a page whose URL has a `file://` scheme, and even then it just lets scripts on that page XHR other `file://` resources. The reader WebView is fed via `loadDataWithBaseURL` and HTTP URLs, not a file URL, so the flag does not change how Google Sans or the user-picked external font is loaded. It is removed in both branches.
- `allowFileAccess = true` is not needed for the `GoogleSans` branch either. Bundled fonts under `file:///android_asset/` load even when `setAllowFileAccess(false)` is in force on every supported Android version, which is the reason Android docs treat `android_asset` as a special case. The flag is removed there.
- The `External` branch genuinely loads a font file the user picked from device storage, so `allowFileAccess = true` is preserved in that branch.

On `minSdk <= 29` (this project ships `minSdk = 26`) `allowFileAccess` and `allowFileAccessFromFileURLs` default to `true`, so the removal in `GoogleSans` is effectively a tightening of WebView posture rather than a redundant change on older devices. On API 30+ both flags default to `false` and the change is a no-op for those devices.